### PR TITLE
affiche le nom de l'évalué-e sur l'écran de fin

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -28,7 +28,7 @@
     },
     "fin": {
       "bravo": {
-        "titre": "Merci et bravo !",
+        "titre": "Merci et bravo {{nom}} !",
         "message": "Allez sur la page suivante pour consulter vos résultats :",
         "bouton": "Suivant"
       },

--- a/src/situations/accueil/vues/fin.vue
+++ b/src/situations/accueil/vues/fin.vue
@@ -5,7 +5,7 @@
       class="modale-interieur bravo">
       <img class="avatar-fin" :src="avatarFin"/>
       <div>
-        <h2>{{ $traduction('accueil.fin.bravo.titre') }}</h2>
+        <h2>{{ $traduction('accueil.fin.bravo.titre', { nom: nom }) }}</h2>
         <div v-if="this.competencesFortes.length != 0">
           <div class="contenu">
             <p class="message-fin">
@@ -55,7 +55,7 @@ import { mapActions, mapState } from 'vuex';
 import 'accueil/styles/fin.scss';
 
 export default {
-  computed: mapState(['competencesFortes']),
+  computed: mapState(['competencesFortes', 'nom']),
 
   data () {
     return {


### PR DESCRIPTION
<img width="1552" alt="Capture d’écran 2019-12-16 à 11 07 42" src="https://user-images.githubusercontent.com/28393/70898111-4ea2e100-1ff4-11ea-9bba-985f1472d95c.png">

Fix #658 