### PR TITLE
permet de copier-coller le texte dans les modales

### DIFF
--- a/src/situations/accueil/styles/fin.scss
+++ b/src/situations/accueil/styles/fin.scss
@@ -1,6 +1,7 @@
 @import 'commun/styles/couleurs.scss';
 
 .overlay.modale {
+  user-select: text;
 
   .modale-interieur.bravo {
     display: flex;


### PR DESCRIPTION
pour fix #663 
![Capture d’écran 2019-12-18 à 11 17 39](https://user-images.githubusercontent.com/28393/71077607-0c120d80-2188-11ea-992b-9d6edf966479.png)

J'ai choisi de le permettre dans toutes les modales, parce que ça m'embêtait de mettre une règle spécifique pour l'écran de fin et que j'ai l'impression que c'est pas un problème.