### PR TITLE
Desactive la selection du texte pour les scènes de jeux (mais pas pour le reste)

### DIFF
--- a/src/situations/accueil/styles/fin.scss
+++ b/src/situations/accueil/styles/fin.scss
@@ -1,7 +1,6 @@
 @import 'commun/styles/couleurs.scss';
 
 .overlay.modale {
-  user-select: text;
 
   .modale-interieur.bravo {
     display: flex;

--- a/src/situations/commun/styles/cadre.scss
+++ b/src/situations/commun/styles/cadre.scss
@@ -6,4 +6,9 @@
   height: $hauteur-scene;
   background: ivory;
   overflow: hidden;
+
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }

--- a/src/situations/commun/styles/conteneur.scss
+++ b/src/situations/commun/styles/conteneur.scss
@@ -8,9 +8,4 @@
   @include ombre;
   height: 41.875rem;
   flex-shrink: 0;
-
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
 }


### PR DESCRIPTION
Il est essentiel d'interdire la sélection du texte dans les scènes de jeux. Pour les pièces du tri ou du contrôle par exemple.

Par contre, on veut autoriser la sélection du texte sur l'écran de fin.

Question : Est-ce que pour les campagnes mTurk, on veut absolument interdire la sélections du nom de l'utilisateur dans la div de progression ?