### PR TITLE
Prévention: affiche les zones

### DIFF
--- a/src/situations/commun/data/scene.js
+++ b/src/situations/commun/data/scene.js
@@ -1,0 +1,12 @@
+const scene = {
+  largeur: 1008,
+  hauteur: 566
+};
+
+export function pourcentageX (valeur) {
+  return valeur / scene.largeur * 100;
+}
+
+export function pourcentageY (valeur) {
+  return valeur / scene.hauteur * 100;
+}

--- a/src/situations/commun/modeles/store.js
+++ b/src/situations/commun/modeles/store.js
@@ -1,7 +1,34 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
 import {
+  CHARGEMENT,
   ACTIVATION_AIDE,
   CHANGEMENT_ETAT
 } from 'commun/modeles/situation';
+
+Vue.use(Vuex);
+
+export function creeStore ({ state, mutations, getters, actions } = {}) {
+  return new Vuex.Store({
+    state: {
+      etat: CHARGEMENT,
+      aide: false,
+      ...state
+    },
+    mutations: {
+      modifieEtat (state, etat) {
+        state.etat = etat;
+      },
+      activeAide (state) {
+        state.aide = true;
+      },
+      ...mutations
+    },
+    getters,
+    actions
+  });
+}
 
 export function synchroniseStoreEtModeleSituation (situation, store) {
   situation.on(CHANGEMENT_ETAT, (etat) => {

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -7,6 +7,7 @@ $bleu: #6E84FE;
 $rouge: #FD5C54;
 $vert-clair: #9ADBD0;
 $gris-clair: #DDDDDD;
+$orange: #FDAF54;
 
 // branding & style-guide
 $couleur-sombre: $bleu-fonce;

--- a/src/situations/commun/vues/adaptateur_situation.js
+++ b/src/situations/commun/vues/adaptateur_situation.js
@@ -2,7 +2,7 @@ import Vue from 'vue';
 
 import { traduction } from 'commun/infra/internationalisation';
 import { synchroniseStoreEtModeleSituation } from 'commun/modeles/store';
-import VueSituation from 'securite/vues/situation.vue';
+import VueSituation from 'commun/vues/situation';
 
 export default class AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources, creeStore, ComposantActe, configurationEntrainement, configurationNormale) {

--- a/src/situations/commun/vues/adaptateur_situation.js
+++ b/src/situations/commun/vues/adaptateur_situation.js
@@ -2,12 +2,13 @@ import Vue from 'vue';
 
 import { traduction } from 'commun/infra/internationalisation';
 import { synchroniseStoreEtModeleSituation } from 'commun/modeles/store';
+import VueSituation from 'securite/vues/situation.vue';
 
 export default class AdaptateurCommunVueSituation {
-  constructor (situation, journal, depotRessources, creeStore, VueSituation) {
+  constructor (situation, journal, depotRessources, creeStore, ComposantActe) {
     this.situation = situation;
     this.creeStore = creeStore;
-    this.VueSituation = VueSituation;
+    this.ComposantActe = ComposantActe;
 
     Vue.prototype.$depotRessources = depotRessources;
     Vue.prototype.$traduction = traduction;
@@ -21,7 +22,11 @@ export default class AdaptateurCommunVueSituation {
     synchroniseStoreEtModeleSituation(this.situation, store);
     new Vue({
       store,
-      render: createEle => createEle(this.VueSituation)
+      render: createEle => createEle(VueSituation, {
+        props: {
+          composantActe: this.ComposantActe
+        }
+      })
     }).$mount(div);
   }
 }

--- a/src/situations/commun/vues/adaptateur_situation.js
+++ b/src/situations/commun/vues/adaptateur_situation.js
@@ -5,10 +5,12 @@ import { synchroniseStoreEtModeleSituation } from 'commun/modeles/store';
 import VueSituation from 'securite/vues/situation.vue';
 
 export default class AdaptateurCommunVueSituation {
-  constructor (situation, journal, depotRessources, creeStore, ComposantActe) {
+  constructor (situation, journal, depotRessources, creeStore, ComposantActe, configurationEntrainement, configurationNormale) {
     this.situation = situation;
     this.creeStore = creeStore;
     this.ComposantActe = ComposantActe;
+    this.configurationEntrainement = configurationEntrainement;
+    this.configurationNormale = configurationNormale;
 
     Vue.prototype.$depotRessources = depotRessources;
     Vue.prototype.$traduction = traduction;
@@ -24,7 +26,9 @@ export default class AdaptateurCommunVueSituation {
       store,
       render: createEle => createEle(VueSituation, {
         props: {
-          composantActe: this.ComposantActe
+          composantActe: this.ComposantActe,
+          configurationEntrainement: this.configurationEntrainement,
+          configurationNormale: this.configurationNormale
         }
       })
     }).$mount(div);

--- a/src/situations/commun/vues/situation.vue
+++ b/src/situations/commun/vues/situation.vue
@@ -7,7 +7,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from '../modeles/store';
+import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from '../modeles/situation';
 
 export default {
   props: {

--- a/src/situations/prevention/data/zones.js
+++ b/src/situations/prevention/data/zones.js
@@ -1,15 +1,4 @@
-const scene = {
-  largeur: 1008,
-  hauteur: 566
-};
-
-export function pourcentageX (valeur) {
-  return valeur / scene.largeur * 100;
-}
-
-export function pourcentageY (valeur) {
-  return valeur / scene.hauteur * 100;
-}
+import { pourcentageX, pourcentageY } from 'commun/data/scene';
 
 const configurationEntrainement = { zones: [] };
 const configurationNormale = {

--- a/src/situations/prevention/data/zones.js
+++ b/src/situations/prevention/data/zones.js
@@ -1,0 +1,26 @@
+const scene = {
+  largeur: 1008,
+  hauteur: 566
+};
+
+export function pourcentageX (valeur) {
+  return valeur / scene.largeur * 100;
+}
+
+export function pourcentageY (valeur) {
+  return valeur / scene.hauteur * 100;
+}
+
+const configurationEntrainement = { zones: [] };
+const configurationNormale = {
+  zones: [
+    {
+      x: pourcentageX(260),
+      y: pourcentageY(280),
+      r: pourcentageX(200),
+      id: 'zone1'
+    }
+  ]
+};
+
+export { configurationEntrainement, configurationNormale };

--- a/src/situations/prevention/data/zones.js
+++ b/src/situations/prevention/data/zones.js
@@ -15,10 +15,34 @@ const configurationEntrainement = { zones: [] };
 const configurationNormale = {
   zones: [
     {
-      x: pourcentageX(260),
-      y: pourcentageY(280),
-      r: pourcentageX(200),
-      id: 'zone1'
+      x: pourcentageX(80),
+      y: pourcentageY(460),
+      r: pourcentageX(80),
+      id: 'fuite-camion-citerne'
+    },
+    {
+      x: pourcentageX(450),
+      y: pourcentageY(390),
+      r: pourcentageX(80),
+      id: 'alcool-pelleteuse'
+    },
+    {
+      x: pourcentageX(490),
+      y: pourcentageY(250),
+      r: pourcentageX(80),
+      id: 'peintre'
+    },
+    {
+      x: pourcentageX(750),
+      y: pourcentageY(340),
+      r: pourcentageX(80),
+      id: 'fuite-gaz'
+    },
+    {
+      x: pourcentageX(870),
+      y: pourcentageY(420),
+      r: pourcentageX(80),
+      id: 'trou'
     }
   ]
 };

--- a/src/situations/prevention/modeles/store.js
+++ b/src/situations/prevention/modeles/store.js
@@ -1,0 +1,25 @@
+import {
+  CHARGEMENT,
+  ENTRAINEMENT_DEMARRE,
+  ENTRAINEMENT_FINI,
+  DEMARRE,
+  FINI
+} from 'commun/modeles/situation';
+import { creeStore as creeStoreCommun } from 'commun/modeles/store';
+
+export function creeStore () {
+  return creeStoreCommun({
+    state: {
+      zones: [],
+      fondSituation: ''
+    },
+    mutations: {
+      configureActe (state, { zones, fondSituation }) {
+        state.zones = zones;
+        state.fondSituation = fondSituation;
+      }
+    }
+  });
+}
+
+export { CHARGEMENT, ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI };

--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -1,0 +1,11 @@
+@import 'commun/styles/couleurs.scss';
+
+.fond-situation {
+  height: 100%;
+}
+
+.zone {
+  fill: transparent;
+  stroke: $orange;
+  stroke-width: 12px;
+}

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -1,0 +1,18 @@
+<template>
+  <div
+    :style="{ 'background-image': `url(${fondSituation})` }"
+    class="fond-situation"
+  >
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import 'securite/styles/acte.scss';
+
+export default {
+  computed: {
+    ...mapState(['fondSituation'])
+  }
+};
+</script>

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -10,7 +10,7 @@
         :cx="`${zone.x}%`"
         :cy="`${zone.y}%`"
         :r="`${zone.r}%`"
-        class="zone zone-selectionnee"
+        class="zone"
       />
     </svg>
   </div>
@@ -18,7 +18,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import 'securite/styles/acte.scss';
+import 'prevention/styles/acte.scss';
 
 export default {
   computed: {

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -3,6 +3,16 @@
     :style="{ 'background-image': `url(${fondSituation})` }"
     class="fond-situation"
   >
+    <svg height="100%" width="100%">
+      <circle
+        v-for="zone in zones"
+        :key="zone.id"
+        :cx="`${zone.x}%`"
+        :cy="`${zone.y}%`"
+        :r="`${zone.r}%`"
+        class="zone zone-selectionnee"
+      />
+    </svg>
   </div>
 </template>
 
@@ -12,7 +22,7 @@ import 'securite/styles/acte.scss';
 
 export default {
   computed: {
-    ...mapState(['fondSituation'])
+    ...mapState(['fondSituation', 'zones'])
   }
 };
 </script>

--- a/src/situations/prevention/vues/situation.js
+++ b/src/situations/prevention/vues/situation.js
@@ -1,10 +1,10 @@
 import AdaptateurCommunVueSituation from 'commun/vues/adaptateur_situation';
 
 import { creeStore } from 'securite/modeles/store';
-import VueSituation from 'securite/vues/situation.vue';
+import ActePrevention from 'prevention/vues/acte';
 
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources) {
-    super(situation, journal, depotRessources, creeStore, VueSituation);
+    super(situation, journal, depotRessources, creeStore, ActePrevention);
   }
 }

--- a/src/situations/prevention/vues/situation.js
+++ b/src/situations/prevention/vues/situation.js
@@ -1,10 +1,11 @@
 import AdaptateurCommunVueSituation from 'commun/vues/adaptateur_situation';
 
-import { creeStore } from 'prevention/modeles/store';
-import ActePrevention from 'prevention/vues/acte';
+import { configurationEntrainement, configurationNormale } from '../data/zones';
+import { creeStore } from '../modeles/store';
+import ActePrevention from './acte';
 
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources) {
-    super(situation, journal, depotRessources, creeStore, ActePrevention);
+    super(situation, journal, depotRessources, creeStore, ActePrevention, configurationEntrainement, configurationNormale);
   }
 }

--- a/src/situations/prevention/vues/situation.js
+++ b/src/situations/prevention/vues/situation.js
@@ -1,6 +1,6 @@
 import AdaptateurCommunVueSituation from 'commun/vues/adaptateur_situation';
 
-import { creeStore } from 'securite/modeles/store';
+import { creeStore } from 'prevention/modeles/store';
 import ActePrevention from 'prevention/vues/acte';
 
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {

--- a/src/situations/securite/data/zones.js
+++ b/src/situations/securite/data/zones.js
@@ -1,15 +1,4 @@
-const scene = {
-  largeur: 1008,
-  hauteur: 566
-};
-
-export function pourcentageX (valeur) {
-  return valeur / scene.largeur * 100;
-}
-
-export function pourcentageY (valeur) {
-  return valeur / scene.hauteur * 100;
-}
+import { pourcentageX, pourcentageY } from 'commun/data/scene';
 
 const DANGER_BOUCHE_EGOUT = 'bouche-egout';
 const DANGER_CASQUE = 'casque';

--- a/src/situations/securite/modeles/store.js
+++ b/src/situations/securite/modeles/store.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import Vuex from 'vuex';
 
 import {
   CHARGEMENT,
@@ -9,18 +8,16 @@ import {
   FINI
 } from 'commun/modeles/situation';
 
-Vue.use(Vuex);
+import { creeStore as creeStoreCommun } from 'commun/modeles/store';
 
 export function creeStore () {
-  return new Vuex.Store({
+  return creeStoreCommun({
     state: {
-      etat: CHARGEMENT,
       zones: [],
       dangers: {},
       fondSituation: '',
       dangersQualifies: {},
-      nonDangersIdentifies: [],
-      aide: false
+      nonDangersIdentifies: []
     },
     getters: {
       qualification (state) {
@@ -31,9 +28,6 @@ export function creeStore () {
       }
     },
     mutations: {
-      modifieEtat (state, etat) {
-        state.etat = etat;
-      },
       configureActe (state, { zones, dangers, fondSituation }) {
         state.zones = zones;
         state.dangers = dangers;
@@ -49,9 +43,6 @@ export function creeStore () {
         if (!state.nonDangersIdentifies.includes(zoneId)) {
           state.nonDangersIdentifies.push(zoneId);
         }
-      },
-      activeAide (state) {
-        state.aide = true;
       }
     }
   });

--- a/src/situations/securite/vues/acte.vue
+++ b/src/situations/securite/vues/acte.vue
@@ -52,7 +52,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 import 'securite/styles/acte.scss';
-import { pourcentageX, pourcentageY } from '../data/zones';
+import { pourcentageX, pourcentageY } from 'commun/data/scene';
 import FenetreZone from './fenetre_zone';
 import EvenementClickHorsZone from '../modeles/evenement_click_hors_zone';
 

--- a/src/situations/securite/vues/situation.js
+++ b/src/situations/securite/vues/situation.js
@@ -1,10 +1,11 @@
 import AdaptateurCommunVueSituation from 'commun/vues/adaptateur_situation';
 
+import { configurationEntrainement, configurationNormale } from '../data/zones';
 import { creeStore } from '../modeles/store';
-import ActeSecurite from 'securite/vues/acte';
+import ActeSecurite from './acte';
 
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources) {
-    super(situation, journal, depotRessources, creeStore, ActeSecurite);
+    super(situation, journal, depotRessources, creeStore, ActeSecurite, configurationEntrainement, configurationNormale);
   }
 }

--- a/src/situations/securite/vues/situation.js
+++ b/src/situations/securite/vues/situation.js
@@ -1,10 +1,10 @@
 import AdaptateurCommunVueSituation from 'commun/vues/adaptateur_situation';
 
 import { creeStore } from '../modeles/store';
-import VueSituation from './situation.vue';
+import ActeSecurite from 'securite/vues/acte';
 
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources) {
-    super(situation, journal, depotRessources, creeStore, VueSituation);
+    super(situation, journal, depotRessources, creeStore, ActeSecurite);
   }
 }

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -1,15 +1,22 @@
 <template>
-  <acte-securite @terminer="changeEtatSituation" />
+  <component
+    :is="composantActe"
+    @terminer="changeEtatSituation"
+  ></component>
 </template>
 
 <script>
 import { mapState } from 'vuex';
 import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from '../modeles/store';
-import ActeSecurite from './acte';
 import { configurationEntrainement, configurationNormale } from '../data/zones';
 
 export default {
-  components: { ActeSecurite },
+  props: {
+    composantActe: {
+      type: Object,
+      required: true
+    }
+  },
 
   computed: {
     ...mapState(['etat']),

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -8,11 +8,18 @@
 <script>
 import { mapState } from 'vuex';
 import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from '../modeles/store';
-import { configurationEntrainement, configurationNormale } from '../data/zones';
 
 export default {
   props: {
     composantActe: {
+      type: Object,
+      required: true
+    },
+    configurationEntrainement: {
+      type: Object,
+      required: true
+    },
+    configurationNormale: {
       type: Object,
       required: true
     }
@@ -25,12 +32,12 @@ export default {
       if ([DEMARRE, FINI].includes(this.etat)) {
         return {
           fondSituation: this.$depotRessources.fondSituation().src,
-          ...configurationNormale
+          ...this.configurationNormale
         };
       }
       return {
         fondSituation: this.$depotRessources.fondSituationEntrainement().src,
-        ...configurationEntrainement
+        ...this.configurationEntrainement
       };
     }
   },

--- a/src/situations/tri/data/pieces.js
+++ b/src/situations/tri/data/pieces.js
@@ -1,74 +1,71 @@
-const scene = {
-  largeur: 1008,
-  hauteur: 566
-};
+import { pourcentageX, pourcentageY } from 'commun/data/scene';
 
 const pieces = [
-  { type: 'bonbon3', y: 430 / scene.hauteur * 100, x: 855 / scene.largeur * 100 },
-  { type: 'bonbon6', y: 430 / scene.hauteur * 100, x: 301 / scene.largeur * 100 },
+  { type: 'bonbon3', y: pourcentageY(430), x: pourcentageX(855) },
+  { type: 'bonbon6', y: pourcentageY(430), x: pourcentageX(301) },
 
-  { type: 'bonbon2', y: 433 / scene.hauteur * 100, x: 723 / scene.largeur * 100 },
-  { type: 'bonbon6', y: 433 / scene.hauteur * 100, x: 335 / scene.largeur * 100 },
-  { type: 'bonbon1', y: 433 / scene.hauteur * 100, x: 196 / scene.largeur * 100 },
+  { type: 'bonbon2', y: pourcentageY(433), x: pourcentageX(723) },
+  { type: 'bonbon6', y: pourcentageY(433), x: pourcentageX(335) },
+  { type: 'bonbon1', y: pourcentageY(433), x: pourcentageX(196) },
 
-  { type: 'bonbon8', y: 434 / scene.hauteur * 100, x: 688 / scene.largeur * 100 },
-  { type: 'bonbon7', y: 435 / scene.hauteur * 100, x: 450 / scene.largeur * 100 },
-  { type: 'bonbon7', y: 437 / scene.hauteur * 100, x: 474 / scene.largeur * 100 },
-  { type: 'bonbon2', y: 439 / scene.hauteur * 100, x: 289 / scene.largeur * 100 },
+  { type: 'bonbon8', y: pourcentageY(434), x: pourcentageX(688) },
+  { type: 'bonbon7', y: pourcentageY(435), x: pourcentageX(450) },
+  { type: 'bonbon7', y: pourcentageY(437), x: pourcentageX(474) },
+  { type: 'bonbon2', y: pourcentageY(439), x: pourcentageX(289) },
 
-  { type: 'bonbon2', y: 443 / scene.hauteur * 100, x: 706 / scene.largeur * 100 },
-  { type: 'bonbon8', y: 443 / scene.hauteur * 100, x: 403 / scene.largeur * 100 },
-  { type: 'bonbon11', y: 443 / scene.hauteur * 100, x: 243 / scene.largeur * 100 },
+  { type: 'bonbon2', y: pourcentageY(443), x: pourcentageX(706) },
+  { type: 'bonbon8', y: pourcentageY(443), x: pourcentageX(403) },
+  { type: 'bonbon11', y: pourcentageY(443), x: pourcentageX(243) },
 
-  { type: 'bonbon6', y: 445 / scene.hauteur * 100, x: 387 / scene.largeur * 100 },
-  { type: 'bonbon9', y: 445 / scene.hauteur * 100, x: 231 / scene.largeur * 100 },
+  { type: 'bonbon6', y: pourcentageY(445), x: pourcentageX(387) },
+  { type: 'bonbon9', y: pourcentageY(445), x: pourcentageX(231) },
 
-  { type: 'bonbon3', y: 447 / scene.hauteur * 100, x: 91 / scene.largeur * 100 },
+  { type: 'bonbon3', y: pourcentageY(447), x: pourcentageX(91) },
 
-  { type: 'bonbon12', y: 448 / scene.hauteur * 100, x: 501 / scene.largeur * 100 },
-  { type: 'bonbon12', y: 448 / scene.hauteur * 100, x: 174 / scene.largeur * 100 },
+  { type: 'bonbon12', y: pourcentageY(448), x: pourcentageX(501) },
+  { type: 'bonbon12', y: pourcentageY(448), x: pourcentageX(174) },
 
-  { type: 'bonbon10', y: 450 / scene.hauteur * 100, x: 638 / scene.largeur * 100 },
-  { type: 'bonbon5', y: 450 / scene.hauteur * 100, x: 281 / scene.largeur * 100 },
-  { type: 'bonbon10', y: 450 / scene.hauteur * 100, x: 255 / scene.largeur * 100 },
-  { type: 'bonbon12', y: 450 / scene.hauteur * 100, x: 51 / scene.largeur * 100 },
+  { type: 'bonbon10', y: pourcentageY(450), x: pourcentageX(638) },
+  { type: 'bonbon5', y: pourcentageY(450), x: pourcentageX(281) },
+  { type: 'bonbon10', y: pourcentageY(450), x: pourcentageX(255) },
+  { type: 'bonbon12', y: pourcentageY(450), x: pourcentageX(51) },
 
-  { type: 'bonbon9', y: 451 / scene.hauteur * 100, x: 832 / scene.largeur * 100 },
-  { type: 'bonbon11', y: 451 / scene.hauteur * 100, x: 299 / scene.largeur * 100 },
+  { type: 'bonbon9', y: pourcentageY(451), x: pourcentageX(832) },
+  { type: 'bonbon11', y: pourcentageY(451), x: pourcentageX(299) },
 
-  { type: 'bonbon5', y: 452 / scene.hauteur * 100, x: 457 / scene.largeur * 100 },
-  { type: 'bonbon9', y: 453 / scene.hauteur * 100, x: 619 / scene.largeur * 100 },
-  { type: 'bonbon10', y: 455 / scene.hauteur * 100, x: 140 / scene.largeur * 100 },
+  { type: 'bonbon5', y: pourcentageY(452), x: pourcentageX(457) },
+  { type: 'bonbon9', y: pourcentageY(453), x: pourcentageX(619) },
+  { type: 'bonbon10', y: pourcentageY(455), x: pourcentageX(140) },
 
-  { type: 'bonbon12', y: 456 / scene.hauteur * 100, x: 671 / scene.largeur * 100 },
-  { type: 'bonbon3', y: 456 / scene.hauteur * 100, x: 346 / scene.largeur * 100 },
+  { type: 'bonbon12', y: pourcentageY(456), x: pourcentageX(671) },
+  { type: 'bonbon3', y: pourcentageY(456), x: pourcentageX(346) },
 
-  { type: 'bonbon3', y: 458 / scene.hauteur * 100, x: 308 / scene.largeur * 100 },
-  { type: 'bonbon10', y: 462 / scene.hauteur * 100, x: 303 / scene.largeur * 100 },
-  { type: 'bonbon4', y: 463 / scene.hauteur * 100, x: 230 / scene.largeur * 100 },
-  { type: 'bonbon2', y: 464 / scene.hauteur * 100, x: 453 / scene.largeur * 100 },
-  { type: 'bonbon11', y: 466 / scene.hauteur * 100, x: 750 / scene.largeur * 100 },
-  { type: 'bonbon4', y: 468 / scene.hauteur * 100, x: 404 / scene.largeur * 100 },
-  { type: 'bonbon5', y: 469 / scene.hauteur * 100, x: 328 / scene.largeur * 100 },
-  { type: 'bonbon7', y: 470 / scene.hauteur * 100, x: 751 / scene.largeur * 100 },
+  { type: 'bonbon3', y: pourcentageY(458), x: pourcentageX(308) },
+  { type: 'bonbon10', y: pourcentageY(462), x: pourcentageX(303) },
+  { type: 'bonbon4', y: pourcentageY(463), x: pourcentageX(230) },
+  { type: 'bonbon2', y: pourcentageY(464), x: pourcentageX(453) },
+  { type: 'bonbon11', y: pourcentageY(466), x: pourcentageX(750) },
+  { type: 'bonbon4', y: pourcentageY(468), x: pourcentageX(404) },
+  { type: 'bonbon5', y: pourcentageY(469), x: pourcentageX(328) },
+  { type: 'bonbon7', y: pourcentageY(470), x: pourcentageX(751) },
 
-  { type: 'bonbon1', y: 471 / scene.hauteur * 100, x: 632 / scene.largeur * 100 },
-  { type: 'bonbon9', y: 471 / scene.hauteur * 100, x: 605 / scene.largeur * 100 },
-  { type: 'bonbon7', y: 471 / scene.hauteur * 100, x: 440 / scene.largeur * 100 },
+  { type: 'bonbon1', y: pourcentageY(471), x: pourcentageX(632) },
+  { type: 'bonbon9', y: pourcentageY(471), x: pourcentageX(605) },
+  { type: 'bonbon7', y: pourcentageY(471), x: pourcentageX(440) },
 
-  { type: 'bonbon5', y: 473 / scene.hauteur * 100, x: 654 / scene.largeur * 100 },
+  { type: 'bonbon5', y: pourcentageY(473), x: pourcentageX(654) },
 
-  { type: 'bonbon4', y: 474 / scene.hauteur * 100, x: 808 / scene.largeur * 100 },
-  { type: 'bonbon11', y: 474 / scene.hauteur * 100, x: 402 / scene.largeur * 100 },
+  { type: 'bonbon4', y: pourcentageY(474), x: pourcentageX(808) },
+  { type: 'bonbon11', y: pourcentageY(474), x: pourcentageX(402) },
 
-  { type: 'bonbon6', y: 475 / scene.hauteur * 100, x: 374 / scene.largeur * 100 },
+  { type: 'bonbon6', y: pourcentageY(475), x: pourcentageX(374) },
 
-  { type: 'bonbon8', y: 476 / scene.hauteur * 100, x: 713 / scene.largeur * 100 },
-  { type: 'bonbon8', y: 476 / scene.hauteur * 100, x: 106 / scene.largeur * 100 },
+  { type: 'bonbon8', y: pourcentageY(476), x: pourcentageX(713) },
+  { type: 'bonbon8', y: pourcentageY(476), x: pourcentageX(106) },
 
-  { type: 'bonbon1', y: 477 / scene.hauteur * 100, x: 795 / scene.largeur * 100 },
-  { type: 'bonbon4', y: 477 / scene.hauteur * 100, x: 664 / scene.largeur * 100 },
-  { type: 'bonbon1', y: 477 / scene.hauteur * 100, x: 316 / scene.largeur * 100 }
+  { type: 'bonbon1', y: pourcentageY(477), x: pourcentageX(795) },
+  { type: 'bonbon4', y: pourcentageY(477), x: pourcentageX(664) },
+  { type: 'bonbon1', y: pourcentageY(477), x: pourcentageX(316) }
 ];
 
 const bacs = [

--- a/tests/situations/commun/modeles/store.js
+++ b/tests/situations/commun/modeles/store.js
@@ -1,0 +1,70 @@
+import { creeStore, synchroniseStoreEtModeleSituation } from 'commun/modeles/store';
+import Situation, { CHARGEMENT, FINI } from 'commun/modeles/situation';
+
+describe('Le store en commun pour les situations', function () {
+  it("initialise l'état a CHARGEMENT", function () {
+    const store = creeStore();
+    expect(store.state.etat).to.eql(CHARGEMENT);
+  });
+
+  it("permet de changer l'état", function () {
+    const store = creeStore();
+    store.commit('modifieEtat', FINI);
+    expect(store.state.etat).to.eql(FINI);
+  });
+
+  it("permet de synchroniser l'état du modèle situation avec le store", function () {
+    const store = creeStore();
+    const situation = new Situation();
+    synchroniseStoreEtModeleSituation(situation, store);
+    situation.modifieEtat(FINI);
+    expect(store.state.etat).to.eql(FINI);
+  });
+
+  it('permet de synchroniser le store avec le modèle situation', function () {
+    const store = creeStore();
+    const situation = new Situation();
+    synchroniseStoreEtModeleSituation(situation, store);
+    store.commit('modifieEtat', FINI);
+    expect(situation.etat()).to.eql(FINI);
+  });
+
+  it("synchronise seulement les changements d'état du store avec le modèle situation", function () {
+    const store = creeStore();
+    const situation = new Situation();
+    synchroniseStoreEtModeleSituation(situation, store);
+    store.commit('activeAide');
+    expect(situation.etat()).to.eql(CHARGEMENT);
+  });
+
+  it("synchronise l'état initial du modèle situation", function () {
+    const store = creeStore();
+    const situation = new Situation();
+    situation.modifieEtat(FINI);
+    synchroniseStoreEtModeleSituation(situation, store);
+    expect(store.state.etat).to.eql(FINI);
+  });
+
+  it("permet de synchroniser l'aide entre le modèle situation et le store", function () {
+    const store = creeStore();
+    const situation = new Situation();
+    synchroniseStoreEtModeleSituation(situation, store);
+    situation.activeAide();
+    expect(store.state.aide).to.be(true);
+  });
+
+  it("permet de synchroniser l'aide entre le store et le modèle situation", function () {
+    const store = creeStore();
+    const situation = new Situation();
+    synchroniseStoreEtModeleSituation(situation, store);
+    store.commit('activeAide');
+    expect(situation.aideActivee).to.be(true);
+  });
+
+  it("active l'aide", function () {
+    const store = creeStore();
+    expect(store.state.aide).to.be(false);
+    store.commit('activeAide');
+    expect(store.state.aide).to.be(true);
+  });
+});

--- a/tests/situations/commun/vues/situation.js
+++ b/tests/situations/commun/vues/situation.js
@@ -1,9 +1,10 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
-import Situation from 'securite/vues/situation.vue';
+import Situation from 'commun/vues/situation';
 import ActeSecurite from 'securite/vues/acte';
-import { creeStore, ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from 'securite/modeles/store';
+import { creeStore } from 'commun/modeles/store';
+import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE, FINI } from 'commun/modeles/situation';
 
-describe('La vue de la situation Sécurité', function () {
+describe('commun/vues/situation', function () {
   let wrapper;
   let store;
   let localVue;
@@ -19,7 +20,16 @@ describe('La vue de la situation Sécurité', function () {
         return { src: 'fond-situation-entrainement' };
       }
     }();
-    store = creeStore();
+    store = creeStore({
+      state: {
+        zones: []
+      },
+      mutations: {
+        configureActe (state, { zones }) {
+          state.zones = zones;
+        }
+      }
+    });
     wrapper = shallowMount(Situation, {
       store,
       localVue,

--- a/tests/situations/prevention/modeles/store.js
+++ b/tests/situations/prevention/modeles/store.js
@@ -1,0 +1,11 @@
+import { creeStore } from 'prevention/modeles/store';
+
+describe('Le store de la situation sécurité', function () {
+  it("permet la configuration d'un acte", function () {
+    const store = creeStore();
+    const zones = [{ x: 1, y: 2, r: 3 }];
+    store.commit('configureActe', { zones, fondSituation: 'fond' });
+    expect(store.state.zones).to.eql(zones);
+    expect(store.state.fondSituation).to.eql('fond');
+  });
+});

--- a/tests/situations/prevention/vues/acte.js
+++ b/tests/situations/prevention/vues/acte.js
@@ -1,0 +1,20 @@
+import { shallowMount } from '@vue/test-utils';
+import ActePrevention from 'prevention/vues/acte';
+import { creeStore } from 'securite/modeles/store';
+
+describe("La vue de l'acte prévention", function () {
+  let wrapper;
+  let store;
+
+  beforeEach(function () {
+    store = creeStore();
+    wrapper = shallowMount(ActePrevention, {
+      store
+    });
+  });
+
+  it('affiche le fond', function () {
+    store.commit('configureActe', { fondSituation: 'fondSituation' });
+    expect(wrapper.attributes('style')).to.eql('background-image: url(fondSituation);');
+  });
+});

--- a/tests/situations/prevention/vues/acte.js
+++ b/tests/situations/prevention/vues/acte.js
@@ -17,4 +17,9 @@ describe("La vue de l'acte prévention", function () {
     store.commit('configureActe', { fondSituation: 'fondSituation' });
     expect(wrapper.attributes('style')).to.eql('background-image: url(fondSituation);');
   });
+
+  it('affiche les zones', function () {
+    store.commit('configureActe', { zones: [{ }] });
+    expect(wrapper.findAll('.zone').length).to.eql(1);
+  });
 });

--- a/tests/situations/securite/modeles/store.js
+++ b/tests/situations/securite/modeles/store.js
@@ -1,19 +1,6 @@
-import { creeStore, CHARGEMENT, FINI } from 'securite/modeles/store';
-import { synchroniseStoreEtModeleSituation } from 'commun/modeles/store';
-import Situation from 'commun/modeles/situation';
+import { creeStore } from 'securite/modeles/store';
 
 describe('Le store de la situation sécurité', function () {
-  it("initialise l'état a CHARGEMENT", function () {
-    const store = creeStore();
-    expect(store.state.etat).to.eql(CHARGEMENT);
-  });
-
-  it("permet de changer l'état", function () {
-    const store = creeStore();
-    store.commit('modifieEtat', FINI);
-    expect(store.state.etat).to.eql(FINI);
-  });
-
   it("permet la configuration d'un acte", function () {
     const store = creeStore();
     const zones = [{ x: 1, y: 2, r: 3 }];
@@ -80,60 +67,5 @@ describe('Le store de la situation sécurité', function () {
     expect(store.state.nonDangersIdentifies).to.eql(['zone1']);
     store.commit('ajouteNonDangerIdentifie', 'zone1');
     expect(store.state.nonDangersIdentifies).to.eql(['zone1']);
-  });
-
-  it("permet de synchroniser l'état du modèle situation avec le store", function () {
-    const store = creeStore();
-    const situation = new Situation();
-    synchroniseStoreEtModeleSituation(situation, store);
-    situation.modifieEtat(FINI);
-    expect(store.state.etat).to.eql(FINI);
-  });
-
-  it('permet de synchroniser le store avec le modèle situation', function () {
-    const store = creeStore();
-    const situation = new Situation();
-    synchroniseStoreEtModeleSituation(situation, store);
-    store.commit('modifieEtat', FINI);
-    expect(situation.etat()).to.eql(FINI);
-  });
-
-  it("synchronise seulement les changements d'état du store avec le modèle situation", function () {
-    const store = creeStore();
-    const situation = new Situation();
-    synchroniseStoreEtModeleSituation(situation, store);
-    store.commit('configureActe', { zones: [], dangers: {} });
-    expect(situation.etat()).to.eql(CHARGEMENT);
-  });
-
-  it("synchronise l'état initial du modèle situation", function () {
-    const store = creeStore();
-    const situation = new Situation();
-    situation.modifieEtat(FINI);
-    synchroniseStoreEtModeleSituation(situation, store);
-    expect(store.state.etat).to.eql(FINI);
-  });
-
-  it("permet de synchroniser l'aide entre le modèle situation et le store", function () {
-    const store = creeStore();
-    const situation = new Situation();
-    synchroniseStoreEtModeleSituation(situation, store);
-    situation.activeAide();
-    expect(store.state.aide).to.be(true);
-  });
-
-  it("permet de synchroniser l'aide entre le  store et le modèle situation", function () {
-    const store = creeStore();
-    const situation = new Situation();
-    synchroniseStoreEtModeleSituation(situation, store);
-    store.commit('activeAide');
-    expect(situation.aideActivee).to.be(true);
-  });
-
-  it("active l'aide", function () {
-    const store = creeStore();
-    expect(store.state.aide).to.be(false);
-    store.commit('activeAide');
-    expect(store.state.aide).to.be(true);
   });
 });

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -24,7 +24,9 @@ describe('La vue de la situation Sécurité', function () {
       store,
       localVue,
       propsData: {
-        composantActe: ActeSecurite
+        composantActe: ActeSecurite,
+        configurationNormale: { zones: [] },
+        configurationEntrainement: { zones: [] }
       }
     });
   });
@@ -44,13 +46,14 @@ describe('La vue de la situation Sécurité', function () {
   });
 
   it("charge les zones d'entrainement au chargement", function () {
-    expect(store.state.zones.length).to.eql(2);
+    expect(store.state.zones.length).to.eql(0);
   });
 
   it('charge les autres zones de la situation une fois démarré', function () {
-    expect(store.state.zones.length).to.eql(2);
+    wrapper.setProps({ configurationNormale: { zones: [1, 2] } });
+    expect(store.state.zones.length).to.eql(0);
     store.commit('modifieEtat', DEMARRE);
-    expect(store.state.zones.length).to.eql(11);
+    expect(store.state.zones.length).to.eql(2);
   });
 
   it("change l'état de la situation en ENTRAINEMENT_FINI une fois l'acte terminé", function () {

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -22,7 +22,10 @@ describe('La vue de la situation Sécurité', function () {
     store = creeStore();
     wrapper = shallowMount(Situation, {
       store,
-      localVue
+      localVue,
+      propsData: {
+        composantActe: ActeSecurite
+      }
     });
   });
 


### PR DESCRIPTION
En plus d'afficher les zones dans la situation prévention, cette PR sépare le store de sécurité et de prévention ainsi que les vue Acte (mais garde une partie en commun).

![Screenshot_2020-01-03 Prévention](https://user-images.githubusercontent.com/86659/71719752-995b9000-2e1f-11ea-84b7-c8b12992a60e.png)


Contribue à #669 