### PR TITLE
Prévention: enregistre le click sur un panneau

### DIFF
--- a/src/situations/prevention/modeles/store.js
+++ b/src/situations/prevention/modeles/store.js
@@ -1,3 +1,4 @@
+import Vue from 'vue';
 import {
   CHARGEMENT,
   ENTRAINEMENT_DEMARRE,
@@ -10,13 +11,22 @@ import { creeStore as creeStoreCommun } from 'commun/modeles/store';
 export function creeStore () {
   return creeStoreCommun({
     state: {
+      evaluationZones: {},
       zones: [],
       fondSituation: ''
+    },
+    getters: {
+      evaluationZone (state) {
+        return (id) => state.evaluationZones[id];
+      }
     },
     mutations: {
       configureActe (state, { zones, fondSituation }) {
         state.zones = zones;
         state.fondSituation = fondSituation;
+      },
+      previentZone (state, { id, panneau }) {
+        Vue.set(state.evaluationZones, id, panneau);
       }
     }
   });

--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -13,6 +13,11 @@
   &-agrandi {
     stroke: $blanc;
   }
+
+  &-traitee {
+    stroke: $blanc;
+    fill: transparentize($orange, 0.2)
+  }
 }
 
 .overlay-zone {

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -22,6 +22,7 @@
       :cx="`${zone.x}%`"
       :cy="`${zone.y}%`"
       :r="`${zone.r}%`"
+      :class="{ 'zone-traitee': $store.getters.evaluationZone(zone.id) }"
       class="zone"
       @mouseover="survoleZone(zone)"
     />

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -59,7 +59,7 @@
         <action-prevention v-if="zonePrevention" />
         <action-evaluation
           v-else
-          @click="previentZone(zoneActive)" />
+          @selectionPanneau="previentZone" />
       </foreignObject>
     </g>
 
@@ -163,9 +163,10 @@ export default {
       this.zonePrevention = null;
     },
 
-    previentZone (zone) {
-      this.zonePrevention = zone;
+    previentZone (panneau) {
+      this.zonePrevention = this.zoneActive;
       this.zoneEvaluee = null;
+      this.$store.commit('previentZone', { id: this.zoneActive.id, panneau });
     },
 
     anime (objet, proprietes) {

--- a/src/situations/prevention/vues/action_evaluation.vue
+++ b/src/situations/prevention/vues/action_evaluation.vue
@@ -2,7 +2,7 @@
   <div class="overlay-zone-evaluation">
     <div
       class="overlay-zone-evaluation-action"
-      @click="clickSurPanneau"
+      @click="clickSurPanneau('ok')"
     >
       <img :src="$depotRessources.ok().src" />
       <svg
@@ -16,7 +16,7 @@
 
     <div
       class="overlay-zone-evaluation-action"
-      @click="clickSurPanneau"
+      @click="clickSurPanneau('danger')"
     >
       <img :src="$depotRessources.danger().src" />
       <svg
@@ -30,7 +30,7 @@
 
     <div
       class="overlay-zone-evaluation-action"
-      @click="clickSurPanneau"
+      @click="clickSurPanneau('urgence')"
     >
       <img :src="$depotRessources.urgence().src" />
       <svg
@@ -49,8 +49,8 @@ import 'prevention/styles/action_evaluation.scss';
 
 export default {
   methods: {
-    clickSurPanneau () {
-      this.$emit('click');
+    clickSurPanneau (panneau) {
+      this.$emit('selectionPanneau', panneau);
     }
   }
 };

--- a/tests/situations/prevention/modeles/store.js
+++ b/tests/situations/prevention/modeles/store.js
@@ -8,4 +8,13 @@ describe('Le store de la situation sécurité', function () {
     expect(store.state.zones).to.eql(zones);
     expect(store.state.fondSituation).to.eql('fond');
   });
+
+  it("permet l'évaluation d'une zone", function () {
+    const store = creeStore();
+    const zones = [{ id: 'zone-test', x: 1, y: 2, r: 3 }];
+    store.commit('configureActe', { zones, fondSituation: 'fond' });
+    store.commit('previentZone', { id: 'zone-test', panneau: 'ok' });
+    expect(store.state.evaluationZones).to.eql({ 'zone-test': 'ok' });
+    expect(store.getters.evaluationZone('zone-test')).to.eql('ok');
+  });
 });

--- a/tests/situations/prevention/vues/acte.js
+++ b/tests/situations/prevention/vues/acte.js
@@ -1,6 +1,6 @@
 import { shallowMount, createLocalVue } from '@vue/test-utils';
 import ActePrevention from 'prevention/vues/acte';
-import { creeStore } from 'securite/modeles/store';
+import { creeStore } from 'prevention/modeles/store';
 import MockDepotRessources from '../aides/mock_depot_ressources_prevention';
 
 describe("La vue de l'acte prévention", function () {


### PR DESCRIPTION
Au click sur un panneau, le résultat est désormais stocké dans le store. La zone est également affiché un peu différemment. 

![prevention-prevention](https://user-images.githubusercontent.com/86659/73168998-61342e00-40fb-11ea-876c-3732c4bf7c76.gif)

Contribue à #669 