### PR TITLE
Prévention: choix d'une action

### DIFF
--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -4,6 +4,7 @@
   fill: transparent;
   stroke: $orange;
   stroke-width: 12px;
+  transition: transform .3s ease, stroke-width .3s ease;
 
   &-clickable {
     stroke: $blanc;
@@ -11,6 +12,12 @@
   }
 
   &-agrandi {
+    stroke-width: 4px;
+    stroke: $blanc;
+  }
+
+  &-reduite {
+    stroke-width: 8px;
     stroke: $blanc;
   }
 

--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -41,3 +41,14 @@
 .overlay-zone-actions-cache {
   transform: translate(0, 100%);
 }
+
+.vient-du-bas-enter-active, .vient-du-bas-leave-active {
+  transition: transform .3s ease;
+}
+.vient-du-bas-enter, .vient-du-bas-leave-to {
+  transform: translate(0, 100%);
+}
+
+.restaure-position-enter, .restaure-position-leave-to {
+  transform: translate(0, 0) !important;
+}

--- a/src/situations/prevention/styles/action_prevention.scss
+++ b/src/situations/prevention/styles/action_prevention.scss
@@ -33,7 +33,6 @@
 
     &:hover {
       clip-path: polygon(20% 0%, 100% 0%, 100% 100%, 5% 100%);
-      z-index: 15;
     }
 
     &.desactivee {

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -5,6 +5,7 @@
       height="100%"
       width="100%"
     />
+    <!-- Définition du disque découpé -->
     <clipPath id="cercle-illustration-clip">
       <transition name="restaure-position">
         <circle
@@ -18,6 +19,7 @@
         />
       </transition>
     </clipPath>
+    <!-- Cercles de zones sauf celui actif -->
     <circle
       v-for="zone in zonesNonActive"
       :key="zone.id"
@@ -28,6 +30,7 @@
       class="zone"
       @mouseover="survoleZone(zone)"
     />
+    <!-- Calque orange de fond lorsqu'une zone est active -->
     <transition-fade>
       <rect
         v-if="zoneActive"
@@ -40,6 +43,7 @@
     </transition-fade>
     <transition name="vient-du-bas">
       <g v-if="zoneEvaluee || zonePrevention">
+        <!-- Rectangle blanc d'interaction -->
         <rect
           :width="`${rectActions.width}%`"
           :height="`${rectActions.height}%`"
@@ -48,6 +52,7 @@
           :rx="rectActions.rx"
           fill="#FBF9FA"
         />
+        <!-- Intérieur du rectangle blanc d'interaction -->
         <foreignObject
           :width="`${rectActions.width}%`"
           :height="`${rectActions.height}%`"
@@ -66,6 +71,7 @@
         </foreignObject>
       </g>
     </transition>
+    <!-- Disque découpé dans l'image de fond -->
     <transition name="restaure-position">
       <image
         v-if="zoneActive"
@@ -78,6 +84,7 @@
         class="transition-transform"
       />
     </transition>
+    <!-- Cercle blanc autour du disque de l'image de fond découpé -->
     <transition name="restaure-position">
       <circle
         v-if="zoneActive"

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -68,8 +68,7 @@
       v-if="zoneActive"
       :xlink:href="fondSituation"
       :style="[ { 'transform-origin': zoneActiveTransformOrigin },
-                   zoneEvaluee ? { transform: transformZone(2) } : '',
-                   zonePrevention ? { transform: transformZone(1) } : '' ]"
+                   zoneEvaluee || zonePrevention ? { transform: transformZone(2) } : '' ]"
       clip-path="url(#cercle-illustration-clip)"
       height="100%"
       width="100%"
@@ -77,12 +76,15 @@
     />
     <circle
       v-if="zoneActive"
-      :cx="`${cercleBlanc.cx}%`"
-      :cy="`${cercleBlanc.cy}%`"
-      :r="`${cercleBlanc.r}%`"
-      :class="{ 'zone-agrandi': zoneEvaluee || zonePrevention,
-                'zone-clickable': zoneSurvolee }"
-      class="zone"
+      :cx="`${zoneActive.x}%`"
+      :cy="`${zoneActive.y}%`"
+      :r="`${zoneActive.r}%`"
+      :class="{ 'zone-agrandi': zoneEvaluee,
+                'zone-clickable': zoneSurvolee,
+                'zone-reduite':  zonePrevention }"
+      :style="[{ 'transform-origin': zoneActiveTransformOrigin },
+                 zoneEvaluee || zonePrevention ? { transform: transformZone(3) } : '' ]"
+      class="zone transition-transform"
       @mouseout="deSurvoleZone"
       @click="evalueZone(zoneActive)"
     />
@@ -99,7 +101,6 @@ import ActionEvaluation from './action_evaluation';
 import ActionPrevention from './action_prevention';
 
 const POSITION_CERCLE_EVALUATION = { x: 50, y: 40 };
-const POSITION_CERCLE_PREVENTION = { x: 50, y: 35 };
 
 const RECTANGLE_EVALUATION = { x: 32, y: 73, width: 35, height: 22, rx: 64 };
 const RECTANGLE_PREVENTION = { x: 21.5, y: 45, width: 57, height: 44.85, rx: 30 };
@@ -116,8 +117,7 @@ export default {
       zoneSurvolee: null,
       zoneEvaluee: null,
       zonePrevention: null,
-      rectActions: {},
-      cercleBlanc: {}
+      rectActions: {}
     };
   },
 
@@ -131,19 +131,16 @@ export default {
     },
     zoneActiveTransformOrigin () {
       return `${this.zoneActive.x}% ${this.zoneActive.y}%`;
-    },
-    positionCercle () {
-      if (this.zonePrevention) {
-        return POSITION_CERCLE_PREVENTION;
-      }
-      return POSITION_CERCLE_EVALUATION;
     }
   },
 
   methods: {
     transformZone (scale) {
-      const scaleInstruction = scale === 1 ? '' : `scale(${scale})`;
-      return `${scaleInstruction} translate(${(this.positionCercle.x - this.zoneActive.x) / scale}%, ${(this.positionCercle.y - this.zoneActive.y) / scale}%)`;
+      let transform = '';
+      if (this.zonePrevention) {
+        transform = `scale(0.5) translate(0, ${-5 / scale * 2}%)`;
+      }
+      return `scale(${scale}) translate(${(POSITION_CERCLE_EVALUATION.x - this.zoneActive.x) / scale}%, ${(POSITION_CERCLE_EVALUATION.y - this.zoneActive.y) / scale}%) ${transform}`;
     },
 
     survoleZone (zone) {
@@ -178,16 +175,10 @@ export default {
     zoneSurvolee (zone) {
       if (!zone) return;
       this.rectActions = { ...RECTANGLE_EVALUATION };
-      this.cercleBlanc = { cx: this.zoneActive.x, cy: this.zoneActive.y, r: this.zoneActive.r };
-    },
-    zoneEvaluee (zone) {
-      if (!zone) return;
-      this.anime(this.cercleBlanc, { r: this.zoneActive.r * 3, cx: this.positionCercle.x, cy: this.positionCercle.y });
     },
     zonePrevention (zone) {
       if (!zone) return;
       this.anime(this.rectActions, RECTANGLE_PREVENTION);
-      this.anime(this.cercleBlanc, { r: this.zoneActive.r * 1.5, cx: this.positionCercle.x, cy: this.positionCercle.y });
     }
   }
 };

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -157,6 +157,7 @@ export default {
     },
 
     evalueZone (zone) {
+      if (this.zonePrevention) return;
       this.zoneEvaluee = zone;
       this.deSurvoleZone();
     },

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -6,15 +6,17 @@
       width="100%"
     />
     <clipPath id="cercle-illustration-clip">
-      <circle
-        v-if="zoneActive"
-        :cx="`${zoneActive.x}%`"
-        :cy="`${zoneActive.y}%`"
-        :r="`${zoneActive.r}%`"
-        :class="{ 'transform-scale-1-5': zoneEvaluee || zonePrevention  }"
-        :style="{ 'transform-origin': zoneActiveTransformOrigin }"
-        class="transition-transform"
-      />
+      <transition name="restaure-position">
+        <circle
+          v-if="zoneActive"
+          :cx="`${zoneActive.x}%`"
+          :cy="`${zoneActive.y}%`"
+          :r="`${zoneActive.r}%`"
+          :class="{ 'transform-scale-1-5': zoneEvaluee || zonePrevention  }"
+          :style="{ 'transform-origin': zoneActiveTransformOrigin }"
+          class="transition-transform"
+        />
+      </transition>
     </clipPath>
     <circle
       v-for="zone in zonesNonActive"
@@ -34,61 +36,64 @@
         width="100%"
         height="100%"
         class="overlay-zone"
-        @click="sortEvaluationZone"
       />
     </transition-fade>
-    <g
-      v-if="zoneActive"
-      :class="{ 'overlay-zone-actions-cache': !zoneEvaluee && !zonePrevention }"
-      class="transition-transform"
-    >
-      <rect
-        :width="`${rectActions.width}%`"
-        :height="`${rectActions.height}%`"
-        :x="`${rectActions.x}%`"
-        :y="`${rectActions.y}%`"
-        :rx="rectActions.rx"
-        fill="#FBF9FA"
+    <transition name="vient-du-bas">
+      <g v-if="zoneEvaluee || zonePrevention">
+        <rect
+          :width="`${rectActions.width}%`"
+          :height="`${rectActions.height}%`"
+          :x="`${rectActions.x}%`"
+          :y="`${rectActions.y}%`"
+          :rx="rectActions.rx"
+          fill="#FBF9FA"
+        />
+        <foreignObject
+          :width="`${rectActions.width}%`"
+          :height="`${rectActions.height}%`"
+          :x="`${rectActions.x}%`"
+          :y="`${rectActions.y}%`"
+          :rx="rectActions.rx"
+        >
+          <action-prevention
+            v-if="zonePrevention"
+            @click="fermeZonePrevention"
+          />
+          <action-evaluation
+            v-else
+            @selectionPanneau="previentZone"
+         />
+        </foreignObject>
+      </g>
+    </transition>
+    <transition name="restaure-position">
+      <image
+        v-if="zoneActive"
+        :xlink:href="fondSituation"
+        :style="[ { 'transform-origin': zoneActiveTransformOrigin },
+                     zoneEvaluee || zonePrevention ? { transform: transformZone(2) } : '' ]"
+        clip-path="url(#cercle-illustration-clip)"
+        height="100%"
+        width="100%"
+        class="transition-transform"
       />
-      <foreignObject
-        :width="`${rectActions.width}%`"
-        :height="`${rectActions.height}%`"
-        :x="`${rectActions.x}%`"
-        :y="`${rectActions.y}%`"
-        :rx="rectActions.rx"
-      >
-        <action-prevention v-if="zonePrevention" />
-        <action-evaluation
-          v-else
-          @selectionPanneau="previentZone" />
-      </foreignObject>
-    </g>
-
-    <image
-      v-if="zoneActive"
-      :xlink:href="fondSituation"
-      :style="[ { 'transform-origin': zoneActiveTransformOrigin },
-                   zoneEvaluee || zonePrevention ? { transform: transformZone(2) } : '' ]"
-      clip-path="url(#cercle-illustration-clip)"
-      height="100%"
-      width="100%"
-      class="transition-transform"
-    />
-    <circle
-      v-if="zoneActive"
-      :cx="`${zoneActive.x}%`"
-      :cy="`${zoneActive.y}%`"
-      :r="`${zoneActive.r}%`"
-      :class="{ 'zone-agrandi': zoneEvaluee,
-                'zone-clickable': zoneSurvolee,
-                'zone-reduite':  zonePrevention }"
-      :style="[{ 'transform-origin': zoneActiveTransformOrigin },
-                 zoneEvaluee || zonePrevention ? { transform: transformZone(3) } : '' ]"
-      class="zone transition-transform"
-      @mouseout="deSurvoleZone"
-      @click="evalueZone(zoneActive)"
-    />
-
+    </transition>
+    <transition name="restaure-position">
+      <circle
+        v-if="zoneActive"
+        :cx="`${zoneActive.x}%`"
+        :cy="`${zoneActive.y}%`"
+        :r="`${zoneActive.r}%`"
+        :class="{ 'zone-agrandi': zoneEvaluee,
+                  'zone-clickable': zoneSurvolee,
+                  'zone-reduite':  zonePrevention }"
+        :style="[{ 'transform-origin': zoneActiveTransformOrigin },
+                   zoneEvaluee || zonePrevention ? { transform: transformZone(3) } : '' ]"
+        class="zone transition-transform"
+        @mouseout="deSurvoleZone"
+        @click="evalueZone(zoneActive)"
+      />
+    </transition>
   </svg>
 </template>
 
@@ -156,15 +161,14 @@ export default {
       this.deSurvoleZone();
     },
 
-    sortEvaluationZone () {
-      this.zoneEvaluee = null;
-      this.zonePrevention = null;
-    },
-
     previentZone (panneau) {
       this.zonePrevention = this.zoneActive;
       this.zoneEvaluee = null;
       this.$store.commit('previentZone', { id: this.zoneActive.id, panneau });
+    },
+
+    fermeZonePrevention () {
+      this.zonePrevention = null;
     },
 
     anime (objet, proprietes) {

--- a/src/situations/prevention/vues/action_prevention.vue
+++ b/src/situations/prevention/vues/action_prevention.vue
@@ -5,12 +5,14 @@
       :class="{ desactivee: survolDroite }"
       @mouseover="survolGauche = true"
       @mouseout="survolGauche = false"
+      @click="$emit('click')"
     />
     <img
       :src="$depotRessources.risque22().src"
       :class="{ desactivee: survolGauche }"
       @mouseover="survolDroite = true"
       @mouseout="survolDroite = false"
+      @click="$emit('click')"
     />
   </div>
 </template>

--- a/tests/situations/prevention/vues/acte.js
+++ b/tests/situations/prevention/vues/acte.js
@@ -66,5 +66,13 @@ describe("La vue de l'acte prévention", function () {
       wrapper.vm.previentZone(zone1);
       expect(wrapper.vm.zoneActive).to.eql(zone1);
     });
+
+    it('ne réouvre pas la zone en mode évaluation si celle ci est en mode prévention', function () {
+      wrapper.vm.survoleZone(zone1);
+      wrapper.vm.evalueZone(zone1);
+      wrapper.vm.previentZone(zone1);
+      wrapper.vm.evalueZone(zone1);
+      expect(wrapper.vm.zoneEvaluee).to.eql(null);
+    });
   });
 });


### PR DESCRIPTION
Pour permettre la sélection d'une action a la fin du processus et l'animation inverse, j'ai réintroduit l'utilisation des transitions css, mais cette fois en les chainant.

![prevention-quitte](https://user-images.githubusercontent.com/86659/73169418-529a4680-40fc-11ea-98f8-a4c1ef54fb82.gif)


Contribue à #669 