### PR TITLE
Supprime des warnings dans les tests.

### DIFF
--- a/tests/situations/accueil/infra/depot_ressources_accueil.js
+++ b/tests/situations/accueil/infra/depot_ressources_accueil.js
@@ -2,6 +2,10 @@ import DepotRessources from 'commun/infra/depot_ressources';
 import DepotRessourcesAccueil from 'accueil/infra/depot_ressources_accueil';
 import chargeurs from '../../commun/aides/mock_chargeurs';
 
+import batimentTri from 'accueil/assets/tri.png';
+import batimentInventaire from 'accueil/assets/inventaire.png';
+import batimentControle from 'accueil/assets/controle.png';
+
 describe('Le dépôt de ressources de la situation accueil', function () {
   let depot;
 
@@ -19,8 +23,8 @@ describe('Le dépôt de ressources de la situation accueil', function () {
   });
 
   it('retourne les bâtiments', function () {
-    expect(depot.batimentSituation('tri')).to.eql('assets/tri.png');
-    expect(depot.batimentSituation('inventaire')).to.eql('assets/inventaire.png');
-    expect(depot.batimentSituation('controle')).to.eql('assets/controle.png');
+    expect(depot.batimentSituation('tri')).to.eql(batimentTri);
+    expect(depot.batimentSituation('inventaire')).to.eql(batimentInventaire);
+    expect(depot.batimentSituation('controle')).to.eql(batimentControle);
   });
 });

--- a/tests/situations/commun/infra/depot_ressources_communes.js
+++ b/tests/situations/commun/infra/depot_ressources_communes.js
@@ -2,6 +2,8 @@ import chargeurs from '../aides/mock_chargeurs';
 import DepotRessources from 'commun/infra/depot_ressources';
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 
+import sonConsigneCommune from 'commun/assets/consigne_commune.wav';
+
 describe('Le dépot de ressources communes', function () {
   let depot;
   let sonConsigneDemarrage;
@@ -26,7 +28,7 @@ describe('Le dépot de ressources communes', function () {
   });
 
   it('charge la consigne commune', function () {
-    expect(sonsCharges).to.contain('assets/consigne_commune.wav');
+    expect(sonsCharges).to.contain(sonConsigneCommune);
   });
 
   it('charge la consigne de demarrage', function () {

--- a/webpack.config-test.js
+++ b/webpack.config-test.js
@@ -39,7 +39,7 @@ var config = {
           {
             loader: 'file-loader',
             options: {
-              name: '[name].[ext]',
+              name: '[name].[contenthash].[ext]',
               outputPath: 'assets'
             }
           }


### PR DESCRIPTION
Spécifiquement ce message
> WARNING in Conflict: Multiple assets emit different content to the same filename assets/consigne_demarrage.wav

Problème réglé dans la config webpack de prod en changeant le nom des
fichiers a la compilation.