### PR TITLE
Supprime la méthode deconnecte qui n'est plus utilisé.

### DIFF
--- a/src/situations/accueil/vues/fin.vue
+++ b/src/situations/accueil/vues/fin.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { mapActions, mapState } from 'vuex';
+import { mapState } from 'vuex';
 import 'accueil/styles/fin.scss';
 
 export default {
@@ -65,8 +65,6 @@ export default {
   },
 
   methods: {
-    ...mapActions(['deconnecte']),
-
     lienSiteVitrine (competence) {
       return `https://eva.beta.gouv.fr/competences/${competence}`;
     },


### PR DESCRIPTION
Elle n'est plus utilisé depuis d7a52e94bca723b916beeb55571b2d1965418f54.