### PR TITLE
Corrige l'affichage des flèches précédentes/suivante sur l'écran d'intro

### DIFF
--- a/src/situations/accueil/vues/accueil.vue
+++ b/src/situations/accueil/vues/accueil.vue
@@ -38,11 +38,13 @@
         </button>
         <span>{{ $traduction('accueil.precedent') }}</span>
       </div>
-      <acces-situation
-        v-if="afficheBoutonSituation"
-        :situation="batiments[indexBatiment]"
-        class="bouton-arrondi"
-      />
+      <div>
+        <acces-situation
+          v-if="afficheBoutonSituation"
+          :situation="batiments[indexBatiment]"
+          class="bouton-arrondi"
+        />
+      </div>
       <div
         :class="{ desactivee: suivantDesactivee}"
         class="bouton-et-etiquette gauche"


### PR DESCRIPTION
Derrière l'écran d'identification et d'intro, on voit que le bouton suivant n'est pas correctement placé, ceci parce que le bouton pour rejoindre une situation n'est pas présent dans ce cas. 
En mettant une div vide, on pousse le bouton a la bonne place.

Avant:

![Screenshot_2020-02-25 eva(4)](https://user-images.githubusercontent.com/86659/75241080-bbd9ac00-57c5-11ea-8c49-3e785d196d9e.png)

Après:

![Screenshot_2020-02-25 eva(3)](https://user-images.githubusercontent.com/86659/75241028-a49abe80-57c5-11ea-9e81-bab932d74813.png)
