### PR TITLE
Corrige le bug de transition sur Chrome pour la situation Prévention

### DIFF
--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -1,5 +1,10 @@
 @import 'commun/styles/couleurs.scss';
 
+.conteneur-prevention {
+  height:100%;
+  width:100%;
+}
+
 .zone {
   fill: transparent;
   stroke: $orange;
@@ -24,6 +29,22 @@
     stroke: $blanc;
     fill: transparentize($orange, 0.2);
     pointer-events: none;
+  }
+}
+
+.vignette-danger {
+  transition: transform .3s ease, border .3s ease;
+  position: absolute;
+  border-radius: 50%;
+  top: 53px;
+  left: calc(50% - 192px);
+
+  &.affichee {
+    width: 384px;
+    height: 384px;
+    border: 24px solid $blanc;
+    transform: scale(0.5) translate(0, -100px);
+    background-size: 470%;
   }
 }
 

--- a/src/situations/prevention/styles/acte.scss
+++ b/src/situations/prevention/styles/acte.scss
@@ -16,9 +16,8 @@
     stroke: $blanc;
   }
 
-  &-reduite {
-    stroke-width: 8px;
-    stroke: $blanc;
+  &-cachee {
+    display: none;
   }
 
   &-traitee {

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -1,109 +1,116 @@
 <template>
-  <svg height="100%" width="100%">
-    <image
-      :xlink:href="fondSituation"
-      height="100%"
-      width="100%"
-    />
-    <!-- Définition du disque découpé -->
-    <clipPath id="cercle-illustration-clip">
+  <div class='conteneur-prevention'>
+    <svg height="100%" width="100%">
+      <image
+        :xlink:href="fondSituation"
+        height="100%"
+        width="100%"
+      />
+      <!-- Définition du disque découpé -->
+      <clipPath id="cercle-illustration-clip">
+        <transition name="restaure-position">
+          <circle
+            v-if="zoneActive"
+            :cx="`${zoneActive.x}%`"
+            :cy="`${zoneActive.y}%`"
+            :r="`${zoneActive.r}%`"
+            :class="{ 'transform-scale-1-5': zoneEvaluee  }"
+            :style="{ 'transform-origin': zoneActiveTransformOrigin }"
+            class="transition-transform"
+          />
+        </transition>
+      </clipPath>
+      <!-- Cercles de zones sauf celui actif -->
+      <circle
+        v-for="zone in zonesNonActive"
+        :key="zone.id"
+        :cx="`${zone.x}%`"
+        :cy="`${zone.y}%`"
+        :r="`${zone.r}%`"
+        :class="{ 'zone-traitee': $store.getters.evaluationZone(zone.id) }"
+        class="zone"
+        @mouseover="survoleZone(zone)"
+      />
+      <!-- Calque orange de fond lorsqu'une zone est active -->
+      <transition-fade>
+        <rect
+          v-if="zoneActive"
+          x="0"
+          y="0"
+          width="100%"
+          height="100%"
+          class="overlay-zone"
+        />
+      </transition-fade>
+      <transition name="vient-du-bas">
+        <g v-if="zoneEvaluee || zonePrevention">
+          <!-- Rectangle blanc d'interaction -->
+          <rect
+            :width="`${rectActions.width}%`"
+            :height="`${rectActions.height}%`"
+            :x="`${rectActions.x}%`"
+            :y="`${rectActions.y}%`"
+            :rx="rectActions.rx"
+            fill="#FBF9FA"
+          />
+          <!-- Intérieur du rectangle blanc d'interaction -->
+          <foreignObject
+            :width="`${rectActions.width}%`"
+            :height="`${rectActions.height}%`"
+            :x="`${rectActions.x}%`"
+            :y="`${rectActions.y}%`"
+            :rx="rectActions.rx"
+          >
+            <action-prevention
+              v-if="zonePrevention"
+              :zone="zoneActive"
+              @selectionPrevention="selectionPrevention"
+            />
+            <action-evaluation
+              v-else
+              @selectionPanneau="previentZone"
+           />
+          </foreignObject>
+        </g>
+      </transition>
+      <!-- Disque découpé dans l'image de fond -->
+      <transition name="restaure-position">
+        <image
+          v-if="zoneActive"
+          :xlink:href="fondSituation"
+          :style="[ { 'transform-origin': zoneActiveTransformOrigin },
+                       zoneEvaluee  ? { transform: transformZone(2) } : '' ]"
+          clip-path="url(#cercle-illustration-clip)"
+          height="100%"
+          width="100%"
+          class="transition-transform"
+          :class="{ 'zone-cachee': zonePrevention }"
+        />
+      </transition>
+      <!-- Cercle blanc autour du disque de l'image de fond découpé -->
       <transition name="restaure-position">
         <circle
           v-if="zoneActive"
           :cx="`${zoneActive.x}%`"
           :cy="`${zoneActive.y}%`"
           :r="`${zoneActive.r}%`"
-          :class="{ 'transform-scale-1-5': zoneEvaluee  }"
-          :style="{ 'transform-origin': zoneActiveTransformOrigin }"
-          class="transition-transform"
+          :class="{ 'zone-agrandi': zoneEvaluee,
+                    'zone-clickable': zoneSurvolee,
+                    'zone-cachee':  zonePrevention }"
+          :style="[{ 'transform-origin': zoneActiveTransformOrigin },
+                     zoneEvaluee ? { transform: transformZone(3) } : '' ]"
+          class="zone transition-transform"
+          @mouseout="deSurvoleZone"
+          @click="evalueZone(zoneActive)"
         />
       </transition>
-    </clipPath>
-    <!-- Cercles de zones sauf celui actif -->
-    <circle
-      v-for="zone in zonesNonActive"
-      :key="zone.id"
-      :cx="`${zone.x}%`"
-      :cy="`${zone.y}%`"
-      :r="`${zone.r}%`"
-      :class="{ 'zone-traitee': $store.getters.evaluationZone(zone.id) }"
-      class="zone"
-      @mouseover="survoleZone(zone)"
+    </svg>
+    <div
+      class='vignette-danger'
+      :class="{ 'affichee': zonePrevention }"
+      :style="imageFondPositionnee"
     />
-    <!-- Calque orange de fond lorsqu'une zone est active -->
-    <transition-fade>
-      <rect
-        v-if="zoneActive"
-        x="0"
-        y="0"
-        width="100%"
-        height="100%"
-        class="overlay-zone"
-      />
-    </transition-fade>
-    <transition name="vient-du-bas">
-      <g v-if="zoneEvaluee || zonePrevention">
-        <!-- Rectangle blanc d'interaction -->
-        <rect
-          :width="`${rectActions.width}%`"
-          :height="`${rectActions.height}%`"
-          :x="`${rectActions.x}%`"
-          :y="`${rectActions.y}%`"
-          :rx="rectActions.rx"
-          fill="#FBF9FA"
-        />
-        <!-- Intérieur du rectangle blanc d'interaction -->
-        <foreignObject
-          :width="`${rectActions.width}%`"
-          :height="`${rectActions.height}%`"
-          :x="`${rectActions.x}%`"
-          :y="`${rectActions.y}%`"
-          :rx="rectActions.rx"
-        >
-          <action-prevention
-            v-if="zonePrevention"
-            :zone="zoneActive"
-            @selectionPrevention="selectionPrevention"
-          />
-          <action-evaluation
-            v-else
-            @selectionPanneau="previentZone"
-         />
-        </foreignObject>
-      </g>
-    </transition>
-    <!-- Disque découpé dans l'image de fond -->
-    <transition name="restaure-position">
-      <image
-        v-if="zoneActive"
-        :xlink:href="fondSituation"
-        :style="[ { 'transform-origin': zoneActiveTransformOrigin },
-                     zoneEvaluee  ? { transform: transformZone(2) } : '' ]"
-        clip-path="url(#cercle-illustration-clip)"
-        height="100%"
-        width="100%"
-        class="transition-transform"
-        :class="{ 'zone-cachee': zonePrevention }"
-      />
-    </transition>
-    <!-- Cercle blanc autour du disque de l'image de fond découpé -->
-    <transition name="restaure-position">
-      <circle
-        v-if="zoneActive"
-        :cx="`${zoneActive.x}%`"
-        :cy="`${zoneActive.y}%`"
-        :r="`${zoneActive.r}%`"
-        :class="{ 'zone-agrandi': zoneEvaluee,
-                  'zone-clickable': zoneSurvolee,
-                  'zone-reduite':  zonePrevention }"
-        :style="[{ 'transform-origin': zoneActiveTransformOrigin },
-                   zoneEvaluee || zonePrevention ? { transform: transformZone(3) } : '' ]"
-        class="zone transition-transform"
-        @mouseout="deSurvoleZone"
-        @click="evalueZone(zoneActive)"
-      />
-    </transition>
-  </svg>
+  </div>
 </template>
 
 <script>
@@ -148,6 +155,13 @@ export default {
     },
     zoneActiveTransformOrigin () {
       return `${this.zoneActive.x}% ${this.zoneActive.y}%`;
+    },
+    imageFondPositionnee () {
+      if (!this.zonePrevention) return '';
+      return [
+        { 'background-image': `url('${this.fondSituation}')` },
+        { 'background-position': `${this.zoneActive.x + this.zoneActive.r}% ${this.zoneActive.y + this.zoneActive.r}%` }
+      ];
     },
     terminee () {
       return this.zones.every(zone => zone.prevention);

--- a/src/situations/prevention/vues/acte.vue
+++ b/src/situations/prevention/vues/acte.vue
@@ -13,7 +13,7 @@
           :cx="`${zoneActive.x}%`"
           :cy="`${zoneActive.y}%`"
           :r="`${zoneActive.r}%`"
-          :class="{ 'transform-scale-1-5': zoneEvaluee || zonePrevention  }"
+          :class="{ 'transform-scale-1-5': zoneEvaluee  }"
           :style="{ 'transform-origin': zoneActiveTransformOrigin }"
           class="transition-transform"
         />
@@ -78,11 +78,12 @@
         v-if="zoneActive"
         :xlink:href="fondSituation"
         :style="[ { 'transform-origin': zoneActiveTransformOrigin },
-                     zoneEvaluee || zonePrevention ? { transform: transformZone(2) } : '' ]"
+                     zoneEvaluee  ? { transform: transformZone(2) } : '' ]"
         clip-path="url(#cercle-illustration-clip)"
         height="100%"
         width="100%"
         class="transition-transform"
+        :class="{ 'zone-cachee': zonePrevention }"
       />
     </transition>
     <!-- Cercle blanc autour du disque de l'image de fond découpé -->
@@ -155,11 +156,7 @@ export default {
 
   methods: {
     transformZone (scale) {
-      let transform = '';
-      if (this.zonePrevention) {
-        transform = `scale(0.5) translate(0, ${-5 / scale * 2}%)`;
-      }
-      return `scale(${scale}) translate(${(POSITION_CERCLE_EVALUATION.x - this.zoneActive.x) / scale}%, ${(POSITION_CERCLE_EVALUATION.y - this.zoneActive.y) / scale}%) ${transform}`;
+      return `scale(${scale}) translate(${(POSITION_CERCLE_EVALUATION.x - this.zoneActive.x) / scale}%, ${(POSITION_CERCLE_EVALUATION.y - this.zoneActive.y) / scale}%)`;
     },
 
     survoleZone (zone) {

--- a/tests/situations/prevention/vues/acte.js
+++ b/tests/situations/prevention/vues/acte.js
@@ -35,6 +35,11 @@ describe("La vue de l'acte prévention", function () {
     expect(wrapper.findAll('.zone').length).to.eql(1);
   });
 
+  it('affiche la vignette du danger', function () {
+    store.commit('configureActe', { zones: [] });
+    expect(wrapper.findAll('.vignette-danger').length).to.eql(1);
+  });
+
   describe('avec 2 zones', function () {
     let zone1;
     let zone2;


### PR DESCRIPTION
https://www.loom.com/share/112969829ef944569c6753dd362b66aa

Fix #755 

Remarque : cette PR introduit un changement de paradigme sur la manière d'afficher les vignettes, on n'utilise plus le SVG. Il s'agit ici d'un premier pas, qui est proposé pour discussion et validation du principe. S'il est validé, il sera intéressant de propager ce principe sur les autres étapes de la vignette.