### PR TITLE
Ne fait pas d'erreur si on ajoute à l'accueil une situation sans bâtiment

### DIFF
--- a/src/situations/accueil/infra/depot_ressources_accueil.js
+++ b/src/situations/accueil/infra/depot_ressources_accueil.js
@@ -50,6 +50,10 @@ export default class DepotRessourcesAccueil extends DepotRessources {
     return this.ressource(avatarAvis);
   }
 
+  existeBatimentSituation (situation) {
+    return !!this.batiments[situation];
+  }
+
   batimentSituation (situation) {
     return this.ressource(this.batiments[situation]);
   }

--- a/src/situations/accueil/vues/acces_situation.vue
+++ b/src/situations/accueil/vues/acces_situation.vue
@@ -2,7 +2,7 @@
   <a
     :href="situation.chemin"
     :class="{ desactivee: desactivee }"
-    :style="{ 'background-image': afficheFond ? backgroundImage : null }"
+    :style="{ 'background-image': afficheBatiment ? backgroundImage : null }"
     v-on="situation.action ? { click: situation.action } : {}"
     @dragstart.prevent
   >
@@ -31,10 +31,14 @@ export default {
     }
   },
 
-  data () {
-    return {
-      backgroundImage: `url('${this.$depotRessources.batimentSituation(this.situation.identifiant).src}')`
-    };
+  computed: {
+    afficheBatiment () {
+      return this.afficheFond && this.$depotRessources.existeBatimentSituation(this.situation.identifiant);
+    },
+
+    backgroundImage () {
+      return `url('${this.$depotRessources.batimentSituation(this.situation.identifiant).src}')`;
+    }
   }
 };
 </script>

--- a/tests/situations/accueil/infra/depot_ressources_accueil.js
+++ b/tests/situations/accueil/infra/depot_ressources_accueil.js
@@ -27,4 +27,9 @@ describe('Le dépôt de ressources de la situation accueil', function () {
     expect(depot.batimentSituation('inventaire')).to.eql(batimentInventaire);
     expect(depot.batimentSituation('controle')).to.eql(batimentControle);
   });
+
+  it('Peut dire si un batiment existe', function () {
+    expect(depot.existeBatimentSituation('situation inconnue')).to.be(false);
+    expect(depot.existeBatimentSituation('tri')).to.be(true);
+  });
 });

--- a/tests/situations/accueil/vues/acces_situation.js
+++ b/tests/situations/accueil/vues/acces_situation.js
@@ -5,16 +5,21 @@ describe('La vue pour accéder à une situation', function () {
   let depotRessources;
   let wrapper;
   let localVue;
+  let existeBatiment;
+  let optionsMount;
 
   beforeEach(function () {
     localVue = createLocalVue();
     depotRessources = new class {
+      existeBatimentSituation (identifiant) {
+        return existeBatiment;
+      }
+
       batimentSituation (identifiant) {
         return { src: identifiant };
       }
     }();
-    localVue.prototype.$depotRessources = depotRessources;
-    wrapper = mount(AccesSituation, {
+    optionsMount = {
       localVue,
       propsData: {
         situation: {
@@ -26,17 +31,35 @@ describe('La vue pour accéder à une situation', function () {
         },
         desactivee: false
       }
-    });
+    };
+    localVue.prototype.$depotRessources = depotRessources;
   });
 
   it("sait s'afficher avec un fond", function () {
-    wrapper.setProps({ afficheFond: true });
+    existeBatiment = true;
+    optionsMount.propsData.afficheFond = true;
+    wrapper = mount(AccesSituation, optionsMount);
     expect(wrapper.text()).to.eql('ABC');
     expect(wrapper.attributes('href')).to.equal('abc.html');
     expect(wrapper.attributes('style')).to.equal('background-image: url(identifiant-abc);');
   });
 
+  it("N'affiche pas le fond s'il n'existe pas, même s'il est demandé", function () {
+    existeBatiment = false;
+    optionsMount.propsData.afficheFond = true;
+    wrapper = mount(AccesSituation, optionsMount);
+
+    expect(wrapper.text()).to.eql('ABC');
+    expect(wrapper.attributes('href')).to.equal('abc.html');
+    expect(wrapper.attributes('style')).to.equal(undefined);
+  });
+
   it("sait s'afficher sans fond", function () {
+    existeBatiment = true;
+    optionsMount.propsData.afficheFond = false;
+    wrapper = mount(AccesSituation, optionsMount);
+    expect(wrapper.text()).to.eql('ABC');
+    expect(wrapper.attributes('href')).to.equal('abc.html');
     expect(wrapper.attributes('style')).to.equal(undefined);
   });
 });


### PR DESCRIPTION
Ce n'est pas normal d'avoir une situation sans bâtiment mais cette correction évitera d'avoir du bruit dans les erreurs rollbard tant que le bâtiment n'est pas là. Si le bâtiment n'est pas là, ça se voit.

fix #826 