### PR TITLE
Ne mount pas de composant question une fois que l'événement de fin a é…

### DIFF
--- a/src/situations/questions/vues/acte.vue
+++ b/src/situations/questions/vues/acte.vue
@@ -24,6 +24,7 @@ import TransitionFade from 'commun/vues/transition_fade';
 import QuestionQcm from 'commun/vues/qcm';
 import QuestionRedactionNote from './redaction_note';
 import 'questions/styles/progression.scss';
+import { FINI } from 'commun/modeles/situation';
 
 export default {
   components: { TransitionFade },
@@ -33,7 +34,7 @@ export default {
     ...mapGetters(['questionCourante', 'nombreQuestions', 'numeroQuestionCourante']),
 
     composantQuestion () {
-      if (!this.questionCourante) return;
+      if (!this.questionCourante || this.etat === FINI) return;
 
       const classesQuestions = {
         redaction_note: QuestionRedactionNote,

--- a/tests/situations/questions/vues/acte.js
+++ b/tests/situations/questions/vues/acte.js
@@ -63,4 +63,11 @@ describe("La vue de l'acte « Question »", function () {
     vue.vm.repondQuestion('Ma réponse');
     expect(vue.contains(QuestionQcm)).to.be(true);
   });
+
+  it('ne mount pas de composant question une fois que la situation est terminée', function () {
+    const vue = shallowMount(Acte, { store, localVue });
+    expect(vue.vm.composantQuestion).to.not.be(undefined);
+    store.commit('modifieEtat', 'fini');
+    expect(vue.vm.composantQuestion).to.be(undefined);
+  });
 });


### PR DESCRIPTION
…té envoyé

J'ai l'impression qu'il y a un bug. En effet il semble que le dernier événement que l'on envoie dans la situation Livraison n'est pas un événement `finSituation` mais un événement `affichageQuestionQcm`. (cf screen ci-dessous) et le lien vers une `Partie`  [sur la staging](https://apipreprod.eva.beta.gouv.fr/admin/campagnes/1b974158-ae0b-4a5d-987b-ce8eecb08703/evenements?q%5Bpartie_session_id_eq%5D=a7af45a3-c07b-4a6b-a119-345ef19d6b2e&commit=Filtrer&campagne_id=1b974158-ae0b-4a5d-987b-ce8eecb08703&order=date_desc) pour illustrer.

<img width="1107" alt="Capture d’écran 2020-04-15 à 09 15 26" src="https://user-images.githubusercontent.com/20596535/79309971-726f2880-7efb-11ea-98f9-55388a9ed86f.png">


