### PR TITLE
Objets trouvés : préchargement des ressources visuelles déclarées dans data

### DIFF
--- a/src/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
+++ b/src/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
@@ -3,10 +3,7 @@ import sonConsigne from 'objets_trouves/assets/consigne_demarrage.wav';
 import sonConsigneTransition from 'objets_trouves/assets/consigne_transition.wav';
 
 import fondSituation from '../assets/accueil.png';
-import fondDeverrouillage from '../assets/fond-vierge.jpg';
 import iconeDeverrouillageDebloque from '../assets/icone-deverrouillage-debloque.png';
-
-import appPhoto from '../assets/app-photo.png';
 
 import sonChoix1 from 'objets_trouves/assets/reponse_jardin_acclimatation.wav';
 import sonChoix2 from 'objets_trouves/assets/reponse_jardin_cirque.wav';
@@ -30,9 +27,26 @@ const MESSAGES = {
 export default class DepotRessourcesObjetsTrouves extends DepotRessourcesCommunes {
   constructor (chargeurs) {
     super(chargeurs, sonConsigne, sonConsigneTransition);
-    this.charge([fondSituation, appPhoto, fondDeverrouillage, iconeDeverrouillageDebloque]);
+    this.charge([fondSituation, iconeDeverrouillageDebloque]);
     this.charge(CHOIX_REPONSES_AUDIO_QCM.agenda);
     this.charge(Object.values(MESSAGES));
+  }
+
+  chargeRessourcesApps (apps) {
+    if (apps) {
+      Object.values(apps).forEach(app => {
+        this.charge(app.map(question => question.illustration));
+        this.charge(app.map(question => question.icone));
+      });
+    }
+  }
+
+  chargeConfigurations (configurationEntrainement, configurationNormale) {
+    const configurations = [configurationEntrainement, configurationNormale];
+    configurations.forEach((configuration) => {
+      this.chargeRessourcesApps(configuration.apps);
+      this.chargeRessourcesApps(configuration.appsAccueilVerrouille);
+    });
   }
 
   fondSituation () {
@@ -47,10 +61,6 @@ export default class DepotRessourcesObjetsTrouves extends DepotRessourcesCommune
     const reponses = CHOIX_REPONSES_AUDIO_QCM[nomQcm];
     if (!reponses) return;
     return reponses[numeroReponse - 1];
-  }
-
-  fondDeverrouillage () {
-    return this.ressource(fondDeverrouillage);
   }
 
   iconeDeverrouillageDebloque () {

--- a/src/situations/objets_trouves/vues/situation.js
+++ b/src/situations/objets_trouves/vues/situation.js
@@ -6,5 +6,6 @@ import ActeObjetsTrouves from './acte';
 export default class AdaptateurVueSituation extends AdaptateurCommunVueSituation {
   constructor (situation, journal, depotRessources) {
     super(situation, journal, depotRessources, creeStore, ActeObjetsTrouves, configurationEntrainement, configurationNormale);
+    depotRessources.chargeConfigurations(configurationEntrainement, configurationNormale);
   }
 }

--- a/tests/situations/objets_trouves/aides/mock_depot_ressources_objets_trouves.js
+++ b/tests/situations/objets_trouves/aides/mock_depot_ressources_objets_trouves.js
@@ -6,8 +6,4 @@ export default class MockDepotRessources {
   fondDeverrouillage () {
     return { src: 'fondDeverrouillage' };
   }
-
-  iconeDeverrouillageDebloque () {
-    return { src: 'iconeDeverrouillageDebloque' };
-  }
 }

--- a/tests/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
+++ b/tests/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
@@ -9,16 +9,54 @@ describe('Le dépot ressource de la situation Objects trouvés', function () {
 
   beforeEach(function () {
     depot = new DepotRessourcesObjetsTrouves(chargeurs());
-    return depot.chargement();
   });
 
-  it("Retourne la réponse d'audio d'un QCM", function () {
-    expect(depot.reponseAudio('agenda', 1)).to.equal(sonChoix1);
-    expect(depot.reponseAudio('questionnaire inconnu', 1)).to.be(undefined);
+  describe('charge les ressources audio', function () {
+    beforeEach(function () {
+      return depot.chargement();
+    });
+
+    it("Retourne la réponse d'audio d'un QCM", function () {
+      expect(depot.reponseAudio('agenda', 1)).to.equal(sonChoix1);
+      expect(depot.reponseAudio('questionnaire inconnu', 1)).to.be(undefined);
+    });
+
+    it("Retourne le message audio d'une question", function () {
+      expect(depot.messageAudio('heure-bureau-mickael')).to.equal(messageMickael);
+      expect(depot.messageAudio('nombre-tours-de-manege')).to.equal(messageRachel);
+    });
   });
 
-  it("Retourne le message audio d'une question", function () {
-    expect(depot.messageAudio('heure-bureau-mickael')).to.equal(messageMickael);
-    expect(depot.messageAudio('nombre-tours-de-manege')).to.equal(messageRachel);
+  describe('charge les ressources visuelles', function () {
+    it('de la configuration entrainement', function () {
+      depot.chargeConfigurations({
+        apps: {
+          agenda: [{ illustration: 'chemin_illustration.png', icone: 'chemin_icone.png' }]
+        }
+      }, {});
+
+      return depot.chargement().then(function () {
+        expect(depot.ressource('chemin_illustration.png')).to.not.be(undefined);
+        expect(depot.ressource('chemin_icone.png')).to.not.be(undefined);
+      });
+    });
+
+    it('de la configuration normale', function () {
+      depot.chargeConfigurations({}, {
+        appsAccueilVerrouille: {
+          deverouillage: [{ illustration: 'chemin_illustration_deverouillage.png', icone: 'chemin_icone_deverrouillage.png' }]
+        },
+        apps: {
+          agenda: [{ illustration: 'chemin_illustration.png', icone: 'chemin_icone.png' }]
+        }
+      });
+
+      return depot.chargement().then(function () {
+        expect(depot.ressource('chemin_illustration.png')).to.not.be(undefined);
+        expect(depot.ressource('chemin_icone.png')).to.not.be(undefined);
+        expect(depot.ressource('chemin_illustration_deverouillage.png')).to.not.be(undefined);
+        expect(depot.ressource('chemin_icone_deverrouillage.png')).to.not.be(undefined);
+      });
+    });
   });
 });


### PR DESCRIPTION
De manière à ne pas dupliquer les noms des applications dans le dépôts
des ressources, j'ai préféré charger les ressources à partir des datas.

Ceci induit le risque qu'une ressource ne soit pas chargée puisqu'on ne
passe pas par dépôt ressources au moment où l'on cherche à l'afficher.
(La vue utilise directement la données qui se trouve dans data).
A noter que ce risque a déjà été pris pour les MES Question et Livraison,
bien que ce soit pour une raison différente.

fix #863 