### PR TITLE
Corrige les warnings silencieux de la suite de test

### DIFF
--- a/src/situations/objets_trouves/modeles/store.js
+++ b/src/situations/objets_trouves/modeles/store.js
@@ -28,6 +28,7 @@ export function creeStore () {
       etatTelephone: null,
       consignesEcranAccueil: []
     },
+
     getters: {
       nombreApps (state, getters) {
         return Object.keys(getters.toutesLesApps).length;
@@ -48,13 +49,16 @@ export function creeStore () {
       },
       consigneEcranAccueil (state) {
         return () => {
-          if (state.indexConsigne < state.consignesEcranAccueil.length - 1) {
-            state.indexConsigne++;
+          if (state.consignesEcranAccueil) {
+            if (state.indexConsigne < state.consignesEcranAccueil.length - 1) {
+              state.indexConsigne++;
+            }
+            return state.consignesEcranAccueil[state.indexConsigne];
           }
-          return state.consignesEcranAccueil[state.indexConsigne];
         };
       }
     },
+
     mutations: {
       configureActe (state, { appsAccueilVerrouille, apps, consignesEcranAccueil, questionsFin, etatTelephone }) {
         state.appsAccueilVerrouille = appsAccueilVerrouille;

--- a/tests/situations/objets_trouves/modeles/store.js
+++ b/tests/situations/objets_trouves/modeles/store.js
@@ -105,4 +105,10 @@ describe('Le store de la situation objets trouvés', function () {
     expect(store.getters.consigneEcranAccueil()).to.eql('Consigne 2');
     expect(store.getters.consigneEcranAccueil()).to.eql('Consigne 2');
   });
+
+  it("Ne renvoie pas de consigne s'il n'y a pas de consigne pour l'écran d'accueil", function () {
+    const store = creeStore();
+    store.commit('configureActe', { });
+    expect(store.getters.consigneEcranAccueil()).to.be(undefined);
+  });
 });


### PR DESCRIPTION
Corrige l'erreur 
```
---> <Accueil> at src/situations/objets_trouves/vues/accueil.vue
       <Root>
TypeError: Cannot read property 'length' of undefined
    at Proxy.eval (webpack:///./src/situations/objets_trouves/modeles/store.js?:64:65)
    at Proxy.render (webpack:///./src/situations/objets_trouves/vues/accueil.vue?./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options:109:49)
    at VueComponent.Vue._render (/app/node_modules/vue/dist/vue.runtime.common.dev.js:3538:22)
    at VueComponent.updateComponent (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4054:21)
    at Watcher.get (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4465:25)
    at Watcher.run (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4540:22)
    at flushSchedulerQueue (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4298:13)
    at queueWatcher (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4387:9)
    at Watcher.update (/app/node_modules/vue/dist/vue.runtime.common.dev.js:4530:5)
```

Présente par exemple pour les tests de la vue accueil. 
