### PR TITLE
Corrige dernier événement questions

### DIFF
--- a/src/situations/commun/vues/qcm.vue
+++ b/src/situations/commun/vues/qcm.vue
@@ -91,12 +91,22 @@ export default {
     question: {
       type: Object,
       required: true
+    },
+    envoyerEvenementAffichage: {
+      type: Boolean,
+      required: false,
+      default: true
     }
   },
 
   mounted () {
-    const evenement = new EvenementAffichageQuestionQCM({ question: this.question.id, metacompetence: this.question.metacompetence });
-    this.$journal.enregistre(evenement);
+    if (this.envoyerEvenementAffichage) {
+      const evenement = new EvenementAffichageQuestionQCM({
+        question: this.question.id,
+        metacompetence: this.question.metacompetence
+      });
+      this.$journal.enregistre(evenement);
+    }
   },
 
   data () {

--- a/src/situations/questions/modeles/store.js
+++ b/src/situations/questions/modeles/store.js
@@ -11,31 +11,30 @@ export function creeStore () {
   return creeStoreCommun({
     state: {
       questions: [],
-      indexQuestions: 0
+      indexQuestions: 0,
+      fini: false
     },
     getters: {
       nombreQuestions (state) {
         return state.questions.length;
       },
       questionCourante (state) {
-        let index = state.indexQuestions;
-        if (index === state.questions.length) {
-          index = index - 1;
-        }
-        return state.questions[index];
-      },
-      numeroQuestionCourante (state, getters) {
-        return state.questions.findIndex((question) => question === getters.questionCourante) + 1;
+        return state.questions[state.indexQuestions];
       }
     },
     mutations: {
       configureActe (state, { questions }) {
         state.questions = questions;
         state.indexQuestions = 0;
+        state.fini = false;
       },
 
       repondQuestionCourante (state, reponse) {
-        state.indexQuestions += 1;
+        if (state.indexQuestions + 1 === state.questions.length) {
+          state.fini = true;
+        } else {
+          state.indexQuestions++;
+        }
       }
     }
   });

--- a/src/situations/questions/vues/acte.vue
+++ b/src/situations/questions/vues/acte.vue
@@ -7,6 +7,7 @@
         :is="composantQuestion"
         :question="questionCourante"
         @reponse="repondQuestion"
+        :envoyerEvenementAffichage="acteEnCours"
       >
         <div class="question-progression">
           {{ indexQuestions + 1 }}/{{ nombreQuestions }}
@@ -24,6 +25,7 @@ import TransitionFade from 'commun/vues/transition_fade';
 import QuestionQcm from 'commun/vues/qcm';
 import QuestionRedactionNote from './redaction_note';
 import 'questions/styles/progression.scss';
+import { DEMARRE } from 'commun/modeles/situation';
 
 export default {
   components: { TransitionFade },
@@ -40,6 +42,9 @@ export default {
         qcm: QuestionQcm
       };
       return classesQuestions[this.questionCourante.type];
+    },
+    acteEnCours () {
+      return this.etat === DEMARRE;
     }
   },
 

--- a/src/situations/questions/vues/acte.vue
+++ b/src/situations/questions/vues/acte.vue
@@ -9,7 +9,7 @@
         @reponse="repondQuestion"
       >
         <div class="question-progression">
-          {{ numeroQuestionCourante }}/{{ nombreQuestions }}
+          {{ indexQuestions + 1 }}/{{ nombreQuestions }}
         </div>
       </component>
     </transition-fade>
@@ -24,17 +24,16 @@ import TransitionFade from 'commun/vues/transition_fade';
 import QuestionQcm from 'commun/vues/qcm';
 import QuestionRedactionNote from './redaction_note';
 import 'questions/styles/progression.scss';
-import { FINI } from 'commun/modeles/situation';
 
 export default {
   components: { TransitionFade },
 
   computed: {
-    ...mapState(['indexQuestions', 'etat']),
-    ...mapGetters(['questionCourante', 'nombreQuestions', 'numeroQuestionCourante']),
+    ...mapState(['indexQuestions', 'etat', 'fini']),
+    ...mapGetters(['questionCourante', 'nombreQuestions']),
 
     composantQuestion () {
-      if (!this.questionCourante || this.etat === FINI) return;
+      if (!this.questionCourante) return;
 
       const classesQuestions = {
         redaction_note: QuestionRedactionNote,
@@ -52,10 +51,8 @@ export default {
   },
 
   watch: {
-    indexQuestions (indexQuestions) {
-      if (indexQuestions === this.nombreQuestions) {
-        this.$emit('terminer');
-      }
+    fini (fini) {
+      if (fini) this.$emit('terminer');
     }
   }
 };

--- a/tests/situations/questions/modeles/store.js
+++ b/tests/situations/questions/modeles/store.js
@@ -7,12 +7,13 @@ describe('Le store de la situation questions', function () {
     expect(store.state.questions.length).to.eql(1);
   });
 
-  it("réinitialise l'index des questions à la configuration d'un acte", function () {
+  it("réinitialise l'index des questions et l'état non fini à la configuration d'un acte", function () {
     const store = creeStore();
     store.commit('configureActe', { questions: [{ id: 1 }] });
     store.commit('repondQuestionCourante', 'reponse');
     store.commit('configureActe', { questions: [{ id: 1 }] });
     expect(store.state.indexQuestions).to.eql(0);
+    expect(store.state.fini).to.eql(false);
   });
 
   it('renvoit le nombre de questions', function () {
@@ -41,19 +42,13 @@ describe('Le store de la situation questions', function () {
     expect(store.getters.questionCourante).to.eql({ id: 1 });
   });
 
-  it('renvoit le numéro de la question courante', function () {
+  it("dit que c'est fini quand toutes les questions ont été répondues", function () {
     const store = creeStore();
-    store.commit('configureActe', { questions: [{ id: 1 }, { id: 2 }] });
-    expect(store.getters.numeroQuestionCourante).to.eql(1);
+    store.commit('configureActe', { questions: [{ id: 'question1' }, { id: 'question2' }] });
+    expect(store.state.fini).to.be(false);
     store.commit('repondQuestionCourante', 'reponse');
-    expect(store.getters.numeroQuestionCourante).to.eql(2);
-  });
-
-  it('renvoit le bon numéro de la question courante une fois terminée', function () {
-    const store = creeStore();
-    store.commit('configureActe', { questions: [{ id: 1 }, { id: 2 }] });
+    expect(store.state.fini).to.be(false);
     store.commit('repondQuestionCourante', 'reponse');
-    store.commit('repondQuestionCourante', 'reponse');
-    expect(store.getters.numeroQuestionCourante).to.eql(2);
+    expect(store.state.fini).to.be(true);
   });
 });

--- a/tests/situations/questions/vues/acte.js
+++ b/tests/situations/questions/vues/acte.js
@@ -1,10 +1,12 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount, createLocalVue, mount } from '@vue/test-utils';
 
 import { creeStore } from 'questions/modeles/store';
 import EvenementReponse from 'questions/modeles/evenement_reponse';
+import EvenementAffichageQuestionQCM from 'commun/modeles/evenement_affichage_question_qcm';
 import Acte from 'questions/vues/acte';
 import QuestionQcm from 'commun/vues/qcm';
 import QuestionRedactionNote from 'questions/vues/redaction_note';
+import { DEMARRE } from 'commun/modeles/situation';
 
 describe("La vue de l'acte « Question »", function () {
   let journal;
@@ -72,5 +74,26 @@ describe("La vue de l'acte « Question »", function () {
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
     expect(vue.contains(QuestionQcm)).to.be(true);
+  });
+
+  it("ne renvoie pas l'événement d'ouverture quand il garde la dernière question affichée", function () {
+    localVue.prototype.$traduction = () => {};
+    var nombreOuverture = 0;
+    localVue.prototype.$journal.enregistre = (evenement) => {
+      if (evenement instanceof EvenementAffichageQuestionQCM) {
+        nombreOuverture++;
+      }
+    };
+    store.commit('configureActe', {
+      questions: [
+        { id: 1, type: 'qcm' },
+        { id: 2, type: 'qcm' }
+      ]
+    });
+    const wrapper = mount(Acte, { store, localVue });
+    store.state.etat = DEMARRE;
+    wrapper.vm.repondQuestion({ reponse: 'Ma réponse' });
+    wrapper.vm.repondQuestion({ reponse: 'Ma réponse' });
+    expect(nombreOuverture).to.eql(2);
   });
 });

--- a/tests/situations/questions/vues/acte.js
+++ b/tests/situations/questions/vues/acte.js
@@ -49,7 +49,7 @@ describe("La vue de l'acte « Question »", function () {
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
   });
 
-  it("envoi l'événement terminer une fois toute les questions passées", function () {
+  it("envoie l'événement terminer une fois toute les questions passées", function () {
     const vue = shallowMount(Acte, { store, localVue });
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
     expect(vue.emitted('terminer')).to.be(undefined);
@@ -57,17 +57,20 @@ describe("La vue de l'acte « Question »", function () {
     expect(vue.emitted('terminer').length).to.eql(1);
   });
 
-  it('garde la dernière question affiché à la fin', function () {
+  it("ne renvoie pas l'événement terminer quand on reconfigure l'acte après avoir terminé l'entrainement", function () {
+    const vue = shallowMount(Acte, { store, localVue });
+    vue.vm.repondQuestion({ reponse: 'Ma réponse' });
+    vue.vm.repondQuestion({ reponse: 'Ma réponse' });
+    store.commit('configureActe', {
+      questions: [{ id: 1, type: 'redaction_note' }]
+    });
+    expect(vue.emitted('terminer').length).to.eql(1);
+  });
+
+  it('garde la dernière question affichée à la fin', function () {
     const vue = shallowMount(Acte, { store, localVue });
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
     vue.vm.repondQuestion({ reponse: 'Ma réponse' });
     expect(vue.contains(QuestionQcm)).to.be(true);
-  });
-
-  it('ne mount pas de composant question une fois que la situation est terminée', function () {
-    const vue = shallowMount(Acte, { store, localVue });
-    expect(vue.vm.composantQuestion).to.not.be(undefined);
-    store.commit('modifieEtat', 'fini');
-    expect(vue.vm.composantQuestion).to.be(undefined);
   });
 });


### PR DESCRIPTION
Dans le cas des abandons on envoyait un événement d'ouverture de question après l'abandon, comme c'était le cas pour la fin.

De plus avec la correction pour le cas de la fin de situation, on avait perdu l'affichage de la dernière question derrière le message "bravo vous avez terminé".

J'ai révisé la façon de traiter la fin des questions et j'ai implémenté l'envoie de l'événement d'ouverture avec une propriété passé à la vue.