### PR TITLE
Agenda Objets trouvés : Sépare la description de l'intitulé de la question

### DIFF
--- a/src/situations/objets_trouves/data/apps.js
+++ b/src/situations/objets_trouves/data/apps.js
@@ -25,7 +25,8 @@ const questionAgendaEntrainement = {
   id: 'agenda-entrainement',
   icone: iconeAgenda,
   illustration: AppAgendaEntrainement,
-  intitule: 'Voici le téléphone de Sophie. Que faisait Sophie ce matin ?',
+  description: 'Voici le téléphone de Sophie.',
+  intitule: 'Que faisait Sophie ce matin ?',
   metacompetence: 'ccf',
   choix: [
     {


### PR DESCRIPTION
Pour correspondre au design présent sur figma, j'ai séparé la description et la question de l'application Agenda de l'entrainement pour objet trouvés.
<img width="1013" alt="Capture d’écran 2020-05-19 à 09 48 22" src="https://user-images.githubusercontent.com/298214/82299707-24e05280-99b6-11ea-8c00-f96c2eada191.png">

