### PR TITLE
Supprime un caractères non affichable qui s'était glissé dans une traduction

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -25,7 +25,7 @@
     },
     "contact": {
       "titre": "Bienvenue {{ nom }} !",
-      "description": "L'équipe eva s'intéresse à l'évolution de votre parcours suite  aux résultats obtenus. Si vous acceptez d’être recontacté·e, merci de nous laisser votre email et votre numéro de téléphone.",
+      "description": "L'équipe eva s'intéresse à l'évolution de votre parcours suite aux résultats obtenus. Si vous acceptez d’être recontacté·e, merci de nous laisser votre email et votre numéro de téléphone.",
       "email": "Votre adresse email",
       "telephone": "Votre numéro de téléphone",
       "bouton": "Démarrer"


### PR DESCRIPTION
Pour corriger le problème suivant :
![image (1)](https://user-images.githubusercontent.com/298214/107933187-b5b48080-6f7e-11eb-9d76-fe87a4a4afdb.png)
