### PR TITLE
Mise à jour du style de la note de rédaction

### DIFF
--- a/src/situations/questions/styles/redaction_note.scss
+++ b/src/situations/questions/styles/redaction_note.scss
@@ -17,17 +17,8 @@
   &-objet-reponse {
     margin-bottom: 0;
     padding: 0.937rem 0 1.25rem;
-    border-top: 1px solid #eeeeee;
     font-family: 'Quicksand', sans-serif;
     font-weight: 500;
-  }
-
-  &-message {
-    font-size: 0.75rem;
-    display: flex;
-    align-items: center;
-    margin-bottom: 1.875rem;
-    padding: 0 0.937rem;
   }
 
   &-reponse {
@@ -37,7 +28,6 @@
     text-align: left;
     resize: none;
     border: 1px solid $gris-clair;
-    box-shadow: inset 0px 4px 4px rgba(0, 0, 0, 0.25);
     border-radius: 8px;
 
     &::placeholder {

--- a/src/situations/questions/styles/redaction_note.scss
+++ b/src/situations/questions/styles/redaction_note.scss
@@ -1,27 +1,10 @@
 @import 'commun/styles/couleurs.scss';
 
-.messagerie {
-  p {
-    margin-top: 0;
-  }
-  &-sujet {
-    margin-bottom: 3px;
-    font-weight: 500;
-    font-family: 'Quicksand', sans-serif;
-  }
-  &-expediteur {
-    color: $couleur-legere-accent-et-validation;
-    font-size: 0.75rem;
-    margin-bottom: 1.25rem;
-  }
-  &-objet-reponse {
-    margin-bottom: 0;
-    padding: 0.937rem 0 1.25rem;
-    font-family: 'Quicksand', sans-serif;
+.question-contenu {
+  .intitule-reponse {
     font-weight: 500;
   }
-
-  &-reponse {
+  .reponse-redaction {
     width: 100%;
     height: 184px;
     padding: 0.75rem;

--- a/src/situations/questions/vues/redaction_note.vue
+++ b/src/situations/questions/vues/redaction_note.vue
@@ -8,7 +8,7 @@
     <p class="messagerie-expediteur">{{ question.expediteur }}</p>
     <p
       v-html="question.message"
-      class='messagerie-message'
+      class='question-intitule'
     ></p>
     <p class="messagerie-objet-reponse">{{ question.objet_reponse }}</p>
     <textarea

--- a/src/situations/questions/vues/redaction_note.vue
+++ b/src/situations/questions/vues/redaction_note.vue
@@ -1,20 +1,23 @@
 <template>
   <question
     :question="question"
-    class="question--redaction-note messagerie"
+    class="question--redaction-note"
   >
     <slot />
-    <p class="messagerie-sujet">{{ question.intitule }}</p>
-    <p class="messagerie-expediteur">{{ question.expediteur }}</p>
-    <p
-      v-html="question.message"
-      class='question-intitule'
-    ></p>
-    <p class="messagerie-objet-reponse">{{ question.objet_reponse }}</p>
-    <textarea
-      v-model.trim="reponse"
-      :placeholder="question.entete_reponse"
-      class="messagerie-reponse"></textarea>
+    <div class="question-entete">
+      <p class="question-description">{{ question.description }}</p>
+      <p
+        v-html="question.intitule"
+        class='question-intitule'
+      ></p>
+    </div>
+    <div class="question-contenu">
+      <p class="intitule-reponse">{{ question.intitule_reponse }}</p>
+      <textarea
+        v-model.trim="reponse"
+        :placeholder="question.reponse_placeholder"
+        class="reponse-redaction"></textarea>
+    </div>
     <button
       class="question-bouton bouton-arrondi bouton-arrondi--petit"
       @click="envoi"


### PR DESCRIPTION
Pour répondre au ticket : https://trello.com/c/f1IPFcmu

Cette PR supprime quelques styles CSS. pour compléter la correction, il m'a aussi fallu supprimer l'expéditeur et refaire faire une image de fond. 
J'ai déjà chargé la nouvelle image en production. Je l'ai aussi mise dans le drive `<drive>/Assets_graphiques/4_Bureau/exports_backgrounds/20210215-bg-redaction_note.jpg`

# Avant
![image](https://user-images.githubusercontent.com/298214/107946003-b6561280-6f90-11eb-8f34-818f1294604f.png)

# Après
![Capture d’écran 2021-02-15 à 13 19 10](https://user-images.githubusercontent.com/298214/107945806-72fba400-6f90-11eb-8e0a-0c2a1f56cbf9.png)
