### PR TITLE
Corrige le style de la situation maintenance

### DIFF
--- a/src/situations/maintenance/styles/lexique.scss
+++ b/src/situations/maintenance/styles/lexique.scss
@@ -77,7 +77,7 @@
     align-items: flex-end;
 
     &.touche-gauche {
-      justify-content: end;
+      justify-content: flex-end;
     }
   }
 }

--- a/src/situations/maintenance/vues/touche.vue
+++ b/src/situations/maintenance/vues/touche.vue
@@ -12,8 +12,8 @@
       xmlns="http://www.w3.org/2000/svg">
       <rect
       :transform="transformation"
-      width="24.8325" height="23.58"
-      x="1.5" y="2.14502"
+      width="24" height="24"
+      x="2" y="2"
       rx="6.5"
       stroke="#1E416A" stroke-width="3"/>
       <path

--- a/src/situations/maintenance/vues/touche.vue
+++ b/src/situations/maintenance/vues/touche.vue
@@ -9,10 +9,17 @@
       height="32"
       viewBox="0 0 28 28"
       fill="none"
-      :transform="transformation"
       xmlns="http://www.w3.org/2000/svg">
-      <rect x="1.5" y="2.14502" width="24.8325" height="23.58" rx="6.5" stroke="#1E416A" stroke-width="3"/>
-      <path d="M20.8736 13.9349H7.82715M7.82715 13.9349L13.4185 8.95117M7.82715 13.9349L13.4185 18.9187" stroke="#1E416A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+      <rect
+      :transform="transformation"
+      width="24.8325" height="23.58"
+      x="1.5" y="2.14502"
+      rx="6.5"
+      stroke="#1E416A" stroke-width="3"/>
+      <path
+      :transform="transformation"
+      d="M20.8736 13.9349H7.82715M7.82715 13.9349L13.4185 8.95117M7.82715 13.9349L13.4185 18.9187"
+      stroke="#1E416A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
     </svg>
     <span v-if="label" class="label-droite" >{{ label }}</span>
   </div>
@@ -43,7 +50,7 @@ export default {
 
   computed: {
     transformation () {
-      return `rotate(${this.rotation})`;
+      return `rotate(${this.rotation},14,14)`;
     }
   }
 };

--- a/tests/situations/maintenance/vues/touche.js
+++ b/tests/situations/maintenance/vues/touche.js
@@ -35,7 +35,8 @@ describe('La vue touche de la Maintenance', function () {
     wrapper = shallowMount(Touche, {
       localVue, propsData: { rotation: 90 }
     });
-    expect(wrapper.find('svg').attributes('transform')).to.be('rotate(90)');
+    expect(wrapper.find('rect').attributes('transform')).to.be('rotate(90,14,14)');
+    expect(wrapper.find('path').attributes('transform')).to.be('rotate(90,14,14)');
   });
 
   it('peut changer de couleur', function () {


### PR DESCRIPTION
Ce bug fait suite au ticket : https://trello.com/c/rxM3Wdqb/584-changer-le-visuel-des-boutons-dans-la-maintenance-puisquon-ne-peut-plus-cliquer

![Capture d’écran 2021-05-17 à 18 09 40](https://user-images.githubusercontent.com/7428736/118521600-780cf280-b73b-11eb-899e-6d65e337bda5.png)

![Capture d’écran 2021-05-17 à 18 39 49](https://user-images.githubusercontent.com/7428736/118525278-48f88000-b73f-11eb-99a2-ce4498692f71.png)

