### PR TITLE
Évalué·e hors-ligne, je peux passer l'écran d'accueil

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -7,6 +7,7 @@ import { creeStore } from 'accueil/modeles/store';
 import Index from 'accueil/vues/index';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 import RegistreUtilisateur from 'commun/infra/registre_utilisateur';
+import RegistreCampagne from 'commun/infra/registre_campagne';
 import DepotRessourcesAccueil from 'accueil/infra/depot_ressources_accueil';
 import { erreurVue } from 'commun/infra/report_erreurs';
 
@@ -14,13 +15,14 @@ Vue.config.errorHandler = erreurVue;
 
 function afficheAccueil (pointInsertion) {
   const registreUtilisateur = new RegistreUtilisateur();
+  const registreCampagne = new RegistreCampagne();
 
   const depotRessources = new DepotRessourcesAccueil();
 
   Vue.prototype.$depotRessources = depotRessources;
   Vue.prototype.$traduction = traduction;
 
-  const store = creeStore(registreUtilisateur);
+  const store = creeStore(registreUtilisateur, registreCampagne);
 
   new Vue({
     store,

--- a/src/situations/commun/infra/erreur_campagne.js
+++ b/src/situations/commun/infra/erreur_campagne.js
@@ -1,0 +1,6 @@
+export default class ErreurCampagne extends Error {
+  constructor (...params) {
+    super(...params);
+    this.name = 'ErreurCampagne';
+  }
+}

--- a/src/situations/commun/infra/registre_campagne.js
+++ b/src/situations/commun/infra/registre_campagne.js
@@ -1,0 +1,47 @@
+import jQuery from 'jquery';
+import EventEmitter from 'events';
+import ErreurCampagne from 'commun/infra/erreur_campagne';
+
+export default class RegistreCampagne extends EventEmitter {
+  constructor ($ = jQuery, urlServeur = process.env.URL_API, navigateur = navigator) {
+    super();
+    this.$ = $;
+    this.urlServeur = urlServeur;
+    this.navigateur = navigateur;
+  }
+
+  recupereCampagne (codeCampagne) {
+    return new Promise((resolve, reject) => {
+      if (this.navigateur.onLine) {
+        this.$.ajax({
+          type: 'GET',
+          url: `${this.urlServeur}/api/campagnes/${encodeURI(codeCampagne)}`,
+          contentType: 'application/json; charset=utf-8',
+          success: (campagne) => {
+            const campagneStr = JSON.stringify(campagne);
+            window.localStorage.setItem(this.cleCampagnePourLocalStorage(codeCampagne), campagneStr);
+            resolve(campagne);
+          },
+          error: (xhr) => {
+            if (xhr.status === 404) {
+              resolve(new ErreurCampagne('Code inconnu'));
+            } else {
+              reject(xhr);
+            }
+          }
+        });
+      } else {
+        const localCampagne = window.localStorage[this.cleCampagnePourLocalStorage(codeCampagne)];
+        if (localCampagne) {
+          resolve(JSON.parse(localCampagne));
+        } else {
+          reject(new ErreurCampagne('Code campagne inconnu ou erreur réseau'));
+        }
+      }
+    });
+  }
+
+  cleCampagnePourLocalStorage (codeCampagne) {
+    return `campagne_${codeCampagne}`;
+  }
+}

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -7,24 +7,38 @@ export const CLEF_IDENTIFIANT = 'identifiantUtilisateur';
 export const CHANGEMENT_CONNEXION = 'changementConnexion';
 
 export default class RegistreUtilisateur extends EventEmitter {
-  constructor ($ = jQuery, urlServeur = process.env.URL_API) {
+  constructor ($ = jQuery, urlServeur = process.env.URL_API, navigateur = navigator) {
     super();
     this.$ = $;
     this.urlServeur = urlServeur;
+    this.navigateur = navigateur;
   }
 
   inscris (nom, codeCampagne) {
     return new Promise((resolve, reject) => {
-      this.$.ajax({
-        type: 'POST',
-        url: `${this.urlServeur}/api/evaluations`,
-        data: JSON.stringify({ nom: nom, code_campagne: codeCampagne }),
-        contentType: 'application/json; charset=utf-8',
-        success: resolve,
-        error: reject
-      });
-    }).then((data) => {
-      window.localStorage.setItem(CLEF_IDENTIFIANT, JSON.stringify(data));
+      if (this.navigateur.onLine) {
+        this.$.ajax({
+          type: 'POST',
+          url: `${this.urlServeur}/api/evaluations`,
+          data: JSON.stringify({ nom: nom, code_campagne: codeCampagne }),
+          contentType: 'application/json; charset=utf-8',
+          success: (data) => {
+            const utilisateur = JSON.stringify(data);
+            window.localStorage.setItem(CLEF_IDENTIFIANT, utilisateur);
+            resolve(utilisateur);
+          },
+          error: reject
+        });
+      } else {
+        var data = {
+          id: `temporaire_${nom}`,
+          nom: nom
+        };
+        const utilisateur = JSON.stringify(data);
+        window.localStorage.setItem(CLEF_IDENTIFIANT, utilisateur);
+        resolve(utilisateur);
+      }
+    }).finally(() => {
       window.localStorage.removeItem(CLEF_SITUATIONS_FAITES);
       this.emit(CHANGEMENT_CONNEXION);
     });

--- a/tests/situations/commun/infra/registre_campagne.js
+++ b/tests/situations/commun/infra/registre_campagne.js
@@ -1,0 +1,82 @@
+import RegistreCampagne from 'commun/infra/registre_campagne';
+
+describe('le registre campagne', function () {
+  function unRegistre (id, nom, urlServeur, enLigne = true) {
+    return new RegistreCampagne({
+      ajax (options) {
+        options.success({ id, nom });
+      }
+    }, urlServeur, { onLine: enLigne });
+  }
+
+  beforeEach(function () {
+    window.localStorage.clear();
+  });
+
+  describe('cleCampagnePourLocalStorage', function () {
+    it('retourne la clé de la campagne du localStorage', function () {
+      const registre = unRegistre(1, 'autre test');
+      expect(registre.cleCampagnePourLocalStorage('code de ma campagne')).to.eql('campagne_code de ma campagne');
+    });
+  });
+
+  describe('recupereCampagne', function () {
+    describe('quand on est en ligne', function () {
+      it('enregistre les informations de la campagne en locale', function () {
+        const registre = unRegistre(1, 'autre test');
+        return registre.recupereCampagne('campagne1').then((campagne) => {
+          expect(window.localStorage.campagne_campagne1).to.eql('{"id":1,"nom":"autre test"}');
+          expect(campagne).to.eql({ id: 1, nom: 'autre test' });
+        });
+      });
+
+      it('retourne une erreur si le code campagne est inconnu', function () {
+        const registre = new RegistreCampagne({
+          ajax (options) {
+            options.error({ status: 404 });
+          }
+        }, 'any url', { onLine: true });
+        return registre.recupereCampagne('inconnu').then((erreur) => {
+          expect(erreur.message).to.eql('Code inconnu');
+        });
+      });
+
+      it('Propage les autres erreurs', function () {
+        const uneErreur = { status: 500 };
+        const registre = new RegistreCampagne({
+          ajax (options) {
+            options.error(uneErreur);
+          }
+        }, 'any url', { onLine: true });
+        return registre.recupereCampagne('inconnu').catch((erreur) => {
+          expect(erreur).to.eql(uneErreur);
+        });
+      });
+    });
+
+    describe('quand on est pas en ligne', function () {
+      describe('quand la campagne existe en locale', function () {
+        beforeEach(function () {
+          window.localStorage.campagne_campagne1 = JSON.stringify({ id: 1, nom: 'autre test' });
+        });
+
+        it("retourne une promesse où tout s'est bien passée", function () {
+          const registre = unRegistre(1, 'autre test', 'https://serveur.com/', false);
+          return registre.recupereCampagne('campagne1').then((campagne) => {
+            expect(campagne).to.eql({ id: 1, nom: 'autre test' });
+          });
+        });
+      });
+
+      describe("quand la campagne n'existe pas en locale", function () {
+        it('retourne une promesse avec une erreur gérée', function () {
+          const registre = unRegistre(1, 'autre test', 'https://serveur.com/', false);
+          return registre.recupereCampagne('campagne_absente').catch((erreur) => {
+            expect(erreur.message).to.eql('Code campagne inconnu ou erreur réseau');
+            expect(erreur.name).to.eql('ErreurCampagne');
+          });
+        });
+      });
+    });
+  });
+});

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -1,23 +1,37 @@
 import RegistreUtilisateur, { CHANGEMENT_CONNEXION, CLEF_IDENTIFIANT } from 'commun/infra/registre_utilisateur';
 
 describe('le registre utilisateur', function () {
-  function unRegistre (id, nom, urlServeur) {
+  function unRegistre (id, nom, urlServeur, enLigne = true) {
     return new RegistreUtilisateur({
       ajax (options) {
         options.success({ id, nom });
       }
-    }, urlServeur);
+    }, urlServeur, { onLine: enLigne });
   }
 
   beforeEach(function () {
     window.localStorage.clear();
   });
 
-  it("permet d'inscrire et de récupérer un utilisateur", function () {
-    const registre = unRegistre(1, 'autre test');
-    return registre.inscris('test').then(() => {
-      expect(registre.nom()).to.eql('autre test');
-      expect(registre.idEvaluation()).to.eql(1);
+  describe('quand on est en ligne', function () {
+    it("permet d'inscrire et de récupérer un utilisateur", function () {
+      const registre = unRegistre(1, 'autre test', 'https://serveur.com/', true);
+      return registre.inscris('test').then((utilisateur) => {
+        expect(registre.nom()).to.eql('autre test');
+        expect(registre.idEvaluation()).to.eql(1);
+        expect(utilisateur).to.eql('{"id":1,"nom":"autre test"}');
+      });
+    });
+  });
+
+  describe('quand on est pas en ligne', function () {
+    it('enregistre en local un utilisateur temporaire', function () {
+      const registre = unRegistre(1, 'autre test', 'https://serveur.com/', false);
+      return registre.inscris('Jean').then((utilisateur) => {
+        expect(registre.nom()).to.eql('Jean');
+        expect(registre.idEvaluation()).to.eql('temporaire_Jean');
+        expect(utilisateur).to.eql('{"id":"temporaire_Jean","nom":"Jean"}');
+      });
     });
   });
 


### PR DESCRIPTION
Nous avons :
- séparé en deux appels, la récupération de la campagne et de l'evaluation
- créé d'un registre campagne
- ajouté le mode horsligne aux registre des campagnes et des utilisateurs
- géré les erreurs au niveau du store plutôt que la vue du formulaire (peut-être à reprendre)
