### PR TITLE
Met à jour le code de suivi Matomo

### DIFF
--- a/src/public/template_index.html
+++ b/src/public/template_index.html
@@ -24,10 +24,10 @@
       _paq.push(['enableLinkTracking']);
       (function() {
         var u="https://stats.data.gouv.fr/";
-        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
         _paq.push(['setSiteId', '<%= process.env.MATOMO_ID %>']);
         var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
       })();
     </script>
     <!-- End Matomo Code -->


### PR DESCRIPTION
Le tracking ne fonctionne pas sur le front, je ne pense pas que ça soit la raison mais en creusant je me suis rendu compte que le script matomo a été renommé. C'est déjà correct sur le serveur et le site, il manquait le front.