### PR TITLE
Fix le clic sur le bouton arrêter la situation

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -187,13 +187,11 @@
       "annuler": "Non",
       "ok": "Oui"
     },
+    "stop": "Attention, vous n'avez pas terminé.<br>Votre résultat sera impacté.<br>Voulez-vous vraiment abandonner ?",
     "reussite": "C'est terminé, bravo !",
     "retour_accueil": "Retour au parc",
     "repeter_consigne": "Répéter la consigne",
-    "abandonner_situation": "Arrêter la situation",
-    "stopsituation": {
-      "stop": "Attention, vous n'avez pas terminé.<br>Votre résultat sera impacté.<br>Voulez-vous vraiment abandonner ?"
-    }
+    "abandonner_situation": "Arrêter la situation"
   },
   "tri": {
     "titre": "Magasin de friandises",

--- a/src/situations/commun/vues/bouton.js
+++ b/src/situations/commun/vues/bouton.js
@@ -11,14 +11,15 @@ export default class VueBouton {
 
   affiche (pointInsertion, $) {
     const $bouton = $(`<a class="${this.classe}"><img src="${this.image}"></a>`);
-    $bouton.on('click', this.click);
-    this.$element = $bouton;
     if (this.etiquette) {
       const $boutonEtEtiquette = $('<div class="bouton-et-etiquette"></div>');
       $boutonEtEtiquette.append($bouton);
       $boutonEtEtiquette.append(`<span>${this.etiquette}</span>`);
       $boutonEtEtiquette.on('click', this.click);
       this.$element = $boutonEtEtiquette;
+    } else {
+      $bouton.on('click', this.click);
+      this.$element = $bouton;
     }
     $(pointInsertion).append(this.$element);
   }

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -31,9 +31,9 @@ describe('vue Stop', function () {
   it('ouvre une fenêtre de confirmation avant de stopper', function () {
     vue.affiche('#point-insertion', $);
 
-    $('#point-insertion .bouton-stop').click();
+    $('#point-insertion .bouton-stop').trigger('click');
     expect($('#fenetre-modale').length).to.equal(1);
-    expect($('h2').text()).to.equal('situation.stopsituation.stop');
+    expect($('h2').text()).to.equal('situation.stop');
   });
 
   it("enregistre l'événement et redirige vers l'accueil quand on confirme la modale", function () {


### PR DESCRIPTION
Pour : https://trello.com/c/RcrO09qT/643-on-a-perdu-le-message-de-stop

Bug suite à : https://trello.com/c/vmAssdUb/624-%C3%A9valu%C3%A9-je-peux-cliquer-le-texte-pour-arr%C3%AAter-une-situation

On ne pouvait plus stopper la situation au clic sur arrêter la situation.

Co-authored-by: Clément Prod'homme <clement@captive.fr>
Co-authored-by: Etienne Charignon <etienne.charignon@beta.gouv.fr>