### PR TITLE
Fix les sons de la situation "objets trouves" et "inventaire" pour safari

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,1 +1,0 @@
-module.exports = 'test-file-stub.jpg';

--- a/__mocks__/fileMock_jpg.js
+++ b/__mocks__/fileMock_jpg.js
@@ -1,1 +1,0 @@
-module.exports = 'test-file-stub.jpg';

--- a/__mocks__/fileMock_png.js
+++ b/__mocks__/fileMock_png.js
@@ -1,1 +1,0 @@
-module.exports = 'test-file-stub.png';

--- a/__mocks__/fileMock_wav.js
+++ b/__mocks__/fileMock_wav.js
@@ -1,1 +1,0 @@
-module.exports = 'test-file-stub.wav';

--- a/__mocks__/fileTransformer.js
+++ b/__mocks__/fileTransformer.js
@@ -1,0 +1,7 @@
+const path = require('path');
+
+module.exports = {
+  process (src, filename, config, options) {
+    return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';';
+  }
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,14 +23,11 @@ module.exports = {
   ],
   transform: {
     '^.+\\.js$': 'babel-jest',
-    '^.+\\.vue$': 'vue-jest'
+    '^.+\\.vue$': 'vue-jest',
+    '\\.(wav|png|jpg|jpeg|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileTransformer.js'
   },
   moduleNameMapper: {
     i18next: '<rootDir>/__mocks__/i18nextMock.js',
-    '\\.wav$': '<rootDir>/__mocks__/fileMock_wav.js',
-    '\\.png$': '<rootDir>/__mocks__/fileMock_png.js',
-    '\\.(jpg|jpeg)$': '<rootDir>/__mocks__/fileMock_jpg.js',
-    '\\.(gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
     '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
     '^(commun|controle|inventaire|maintenance|objets_trouves|prevention|tri)/(.*)$': '<rootDir>/src/situations/$1/$2'
   }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,37 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFiles: [
+    '<rootDir>/.jest/register-context.js'
+  ],
+  setupFilesAfterEnv: [
+    '<rootDir>/.jest/before-after.js'
+  ],
+  modulePaths: [
+    '/shared/vendor/modules'
+  ],
+  moduleFileExtensions: [
+    'js',
+    'jsx',
+    'vue',
+    'test.js'
+  ],
+  moduleDirectories: [
+    'node_modules',
+    'bower_components',
+    'shared',
+    'src/situations'
+  ],
+  transform: {
+    '^.+\\.js$': 'babel-jest',
+    '^.+\\.vue$': 'vue-jest'
+  },
+  moduleNameMapper: {
+    i18next: '<rootDir>/__mocks__/i18nextMock.js',
+    '\\.wav$': '<rootDir>/__mocks__/fileMock_wav.js',
+    '\\.png$': '<rootDir>/__mocks__/fileMock_png.js',
+    '\\.(jpg|jpeg)$': '<rootDir>/__mocks__/fileMock_jpg.js',
+    '\\.(gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|mp3|m4a|aac|oga)$': '<rootDir>/__mocks__/fileMock.js',
+    '\\.(css|less|scss)$': '<rootDir>/__mocks__/styleMock.js',
+    '^(commun|controle|inventaire|maintenance|objets_trouves|prevention|tri)/(.*)$': '<rootDir>/src/situations/$1/$2'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -97,42 +97,5 @@
     "globals": {
       "expect": "readonly"
     }
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "setupFiles": [
-      "<rootDir>/.jest/register-context.js"
-    ],
-    "setupFilesAfterEnv": [
-      "<rootDir>/.jest/before-after.js"
-    ],
-    "modulePaths": [
-      "/shared/vendor/modules"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx",
-      "vue",
-      "test.js"
-    ],
-    "moduleDirectories": [
-      "node_modules",
-      "bower_components",
-      "shared",
-      "src/situations"
-    ],
-    "transform": {
-      "^.+\\.js$": "babel-jest",
-      "^.+\\.vue$": "vue-jest"
-    },
-    "moduleNameMapper": {
-      "i18next": "<rootDir>/__mocks__/i18nextMock.js",
-      "\\.wav$": "<rootDir>/__mocks__/fileMock_wav.js",
-      "\\.png$": "<rootDir>/__mocks__/fileMock_png.js",
-      "\\.(jpg|jpeg)$": "<rootDir>/__mocks__/fileMock_jpg.js",
-      "\\.(gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
-      "^(commun|controle|inventaire|maintenance|objets_trouves|prevention|tri)/(.*)$": "<rootDir>/src/situations/$1/$2"
-    }
   }
 }

--- a/src/app/situation_inventaire.js
+++ b/src/app/situation_inventaire.js
@@ -7,15 +7,9 @@ import DepotRessourcesInventaire from 'inventaire/infra/depot_ressources_inventa
 import Situation from 'inventaire/modeles/situation';
 import VueSituation from 'inventaire/vues/situation';
 
-import reussite from 'inventaire/assets/reussite.wav';
-import echec from 'inventaire/assets/echec.wav';
-
 import { contenants, contenus } from 'inventaire/data/stock';
 
-const situation = new Situation(
-  { contenants, contenus },
-  { reussite, echec }
-);
+const situation = new Situation({ contenants, contenus });
 
 const depotRessources = new DepotRessourcesInventaire();
 afficheSituation('inventaire', situation, VueSituation, depotRessources);

--- a/src/situations/commun/composants/joueur_audio_buffer.js
+++ b/src/situations/commun/composants/joueur_audio_buffer.js
@@ -1,0 +1,12 @@
+export default class JoueurAudioBuffer {
+  start (audioBuffer, callbackFin) {
+    this.sonEnCours = audioBuffer;
+    audioBuffer.start();
+    this.timeoutId = setTimeout(callbackFin, audioBuffer.buffer.duration * 1000);
+  }
+
+  stop () {
+    clearTimeout(this.timeoutId);
+    this.sonEnCours.stop();
+  }
+}

--- a/src/situations/commun/composants/joueur_consigne.js
+++ b/src/situations/commun/composants/joueur_consigne.js
@@ -1,25 +1,17 @@
-export default class JoueurConsigne {
+import JoueurAudioBuffer from 'commun/composants/joueur_audio_buffer';
+
+export default class JoueurConsigne extends JoueurAudioBuffer {
   constructor (depot, ressourceConsigne) {
+    super();
     this.depot = depot;
     this.ressourceConsigne = ressourceConsigne;
   }
 
-  joueSon (noeudSon, callbackFin) {
-    this.sonEnCours = noeudSon;
-    noeudSon.start();
-    this.timeoutId = setTimeout(callbackFin, noeudSon.buffer.duration * 1000);
-  }
-
   joue (jouerConsigneCommune, lectureTerminee) {
     const joueConsigneCommune = () => {
-      this.joueSon(this.depot.consigneCommune(), lectureTerminee);
+      this.start(this.depot.consigneCommune(), lectureTerminee);
     };
-    this.joueSon(this.depot[this.ressourceConsigne](),
+    this.start(this.depot[this.ressourceConsigne](),
       jouerConsigneCommune ? joueConsigneCommune : lectureTerminee);
-  }
-
-  stop () {
-    clearTimeout(this.timeoutId);
-    this.sonEnCours.stop();
   }
 }

--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -1,12 +1,10 @@
 let audioCtx;
 
-const HOST = `${window.location.protocol}//${window.location.host}`;
-
 function chargeurAudio (src, timeout = 2000) {
   audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
   const request = new window.XMLHttpRequest();
 
-  request.open('GET', `${HOST}/${src}`, true);
+  request.open('GET', src, true);
   request.responseType = 'arraybuffer';
 
   const promesse = new Promise((resolve, reject) => {

--- a/src/situations/commun/vues/lecteur_audio.vue
+++ b/src/situations/commun/vues/lecteur_audio.vue
@@ -13,24 +13,23 @@
       <path class="son1" fill-rule="evenodd" clip-rule="evenodd" d="M18.5174 10.5178C19.1032 9.93198 20.0529 9.93198 20.6387 10.5178C21.3586 11.2377 21.9297 12.0924 22.3194 13.033L21.0185 13.5719L22.3194 13.033C22.709 13.9737 22.9095 14.9819 22.9095 16C22.9095 17.0181 22.709 18.0263 22.3194 18.967C21.9297 19.9076 21.3586 20.7623 20.6387 21.4822C20.0529 22.068 19.1032 22.068 18.5174 21.4822C17.9316 20.8964 17.9316 19.9467 18.5174 19.3609C18.9587 18.9195 19.3089 18.3956 19.5477 17.8189C19.7866 17.2422 19.9095 16.6242 19.9095 16C19.9095 15.3758 19.7866 14.7578 19.5477 14.1811L20.9335 13.6071L19.5477 14.1811C19.3089 13.6044 18.9587 13.0804 18.5174 12.6391C17.9316 12.0533 17.9316 11.1036 18.5174 10.5178Z" fill="white"/>
       <path class="son2" fill-rule="evenodd" clip-rule="evenodd" d="M22.0174 7.01777C22.6032 6.43198 23.5529 6.43198 24.1387 7.01777C25.3183 8.19733 26.254 9.59768 26.8923 11.1388C27.5307 12.68 27.8593 14.3318 27.8593 16C27.8593 17.6682 27.5307 19.32 26.8923 20.8611C26.254 22.4023 25.3183 23.8027 24.1387 24.9822C23.5529 25.568 22.6032 25.568 22.0174 24.9822C21.4316 24.3964 21.4316 23.4467 22.0174 22.8609C22.9184 21.9599 23.6331 20.8903 24.1207 19.7131C24.6083 18.5359 24.8593 17.2742 24.8593 16C24.8593 14.7258 24.6083 13.4641 24.1207 12.2869C23.6331 11.1097 22.9184 10.0401 22.0174 9.13909C21.4316 8.5533 21.4316 7.60355 22.0174 7.01777Z" fill="white"/>
     </svg>
-
-    <audio
-      ref="audio"
-      :src="src"
-    />
   </span>
 </template>
 
 <script>
 import 'commun/styles/lecteur_audio.scss';
+import JoueurAudioBuffer from 'commun/composants/joueur_audio_buffer';
 
 export default {
   props: {
-    src: {
+    questionnaire: {
       type: String,
       required: true
     },
-
+    idReponse: {
+      type: Number,
+      required: false
+    },
     joueSon: {
       type: Boolean,
       required: true
@@ -39,18 +38,26 @@ export default {
 
   data () {
     return {
-      enTrainDeJouer: false
+      enTrainDeJouer: false,
+      joueurSon: new JoueurAudioBuffer()
     };
   },
 
-  mounted () {
-    this.$refs.audio.addEventListener('pause', () => { this.enTrainDeJouer = false; });
-    this.$refs.audio.addEventListener('play', () => { this.enTrainDeJouer = true; });
+  watch: {
+    joueSon (joue) {
+      this.enTrainDeJouer = joue;
+      if (joue) {
+        this.joueurSon.start(this.audioBuffer(this.questionnaire, this.idReponse),
+          () => { this.enTrainDeJouer = false; });
+      } else {
+        this.joueurSon.stop();
+      }
+    }
   },
 
-  watch: {
-    joueSon (val) {
-      if (val) this.$refs.audio.play();
+  methods: {
+    audioBuffer (nomQuestionnaire, idReponse) {
+      return this.$depotRessources.reponseAudio(nomQuestionnaire, idReponse);
     }
   }
 

--- a/src/situations/commun/vues/qcm.vue
+++ b/src/situations/commun/vues/qcm.vue
@@ -52,7 +52,8 @@
             <lecteur-audio
               v-if="element.audio"
               :joue-son="reponse == element.id"
-              :src="son(element.audio, element.id)"
+              :questionnaire="element.audio"
+              :idReponse="element.id"
               class="question-reponse-intitule"
             />
             <img
@@ -142,10 +143,6 @@ export default {
     envoi () {
       this.envoyer = true;
       this.$emit('reponse', this.donneesReponse);
-    },
-
-    son (nomQuestionnaire, idReponse) {
-      return this.$depotRessources.reponseAudio(nomQuestionnaire, idReponse);
     }
   }
 };

--- a/src/situations/inventaire/infra/depot_ressources_inventaire.js
+++ b/src/situations/inventaire/infra/depot_ressources_inventaire.js
@@ -6,10 +6,14 @@ import boutonSaisie from 'inventaire/assets/saisie-reponse.svg';
 import loupe from 'inventaire/assets/loupe.svg';
 import retour from 'inventaire/assets/retour.svg';
 
+import reussite from 'inventaire/assets/reussite.wav';
+import echec from 'inventaire/assets/echec.wav';
+
 export default class DepotRessourcesInventaire extends DepotRessourcesCommunes {
   constructor (chargeurs) {
     super(chargeurs, sonConsigne);
     this.charge([croixRetourStock, boutonSaisie, loupe, retour]);
+    this.charge([reussite, echec]);
     this.chargeContexte(require.context('../assets'));
   }
 
@@ -31,5 +35,13 @@ export default class DepotRessourcesInventaire extends DepotRessourcesCommunes {
 
   imageAideComplementaire () {
     return this.calculatrice();
+  }
+
+  sonReussite () {
+    return this.ressource(reussite);
+  }
+
+  sonEchec () {
+    return this.ressource(echec);
   }
 }

--- a/src/situations/inventaire/modeles/situation.js
+++ b/src/situations/inventaire/modeles/situation.js
@@ -32,14 +32,10 @@ function creerContenants ({ contenants, contenus }) {
 }
 
 export default class Situation extends SituationCommune {
-  constructor (unStock, sons) {
+  constructor (unStock) {
     super({ aideDisponible: true });
     this.produits = inventaireProduits(unStock);
     this.contenants = creerContenants(unStock);
-    this.audios = {
-      reussite: new window.Audio(sons.reussite),
-      echec: new window.Audio(sons.echec)
-    };
   }
 
   inventaireReference () {

--- a/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
+++ b/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
@@ -99,10 +99,10 @@ export function initialiseFormulaireSaisieInventaire (situation, pointInsertion,
       journal.enregistre(new EvenementSaisieInventaire({ reussite, resultatValidation: saisieValide, reponses }));
       $('.erreur-saisie').toggleClass('invisible', reussite);
       if (reussite) {
-        situation.audios.reussite.play();
+        depotRessources.sonReussite().start();
         situation.modifieEtat(FINI);
       } else {
-        situation.audios.echec.play();
+        depotRessources.sonEchec().start();
       }
     });
 

--- a/src/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
+++ b/src/situations/objets_trouves/infra/depot_ressources_objets_trouves.js
@@ -60,7 +60,7 @@ export default class DepotRessourcesObjetsTrouves extends DepotRessourcesCommune
   reponseAudio (nomQcm, numeroReponse) {
     const reponses = CHOIX_REPONSES_AUDIO_QCM[nomQcm];
     if (!reponses) return;
-    return reponses[numeroReponse - 1];
+    return this.ressource(reponses[numeroReponse - 1]);
   }
 
   iconeDeverrouillageDebloque () {
@@ -68,7 +68,7 @@ export default class DepotRessourcesObjetsTrouves extends DepotRessourcesCommune
   }
 
   messageAudio (questionId) {
-    return MESSAGES[questionId];
+    return this.ressource(MESSAGES[questionId]);
   }
 
   imageAideComplementaire () {

--- a/src/situations/objets_trouves/vues/bouton-lecture.vue
+++ b/src/situations/objets_trouves/vues/bouton-lecture.vue
@@ -26,15 +26,15 @@
         />
       </svg>
     </button>
-    <audio ref="audio" :src="sonMessage" />
   </div>
 </template>
 
 <script>
+import JoueurAudioBuffer from 'commun/composants/joueur_audio_buffer';
 
 export default {
   props: {
-    sonMessage: {
+    idQuestion: {
       type: String,
       required: true
     }
@@ -42,22 +42,27 @@ export default {
 
   data () {
     return {
-      joueSon: false
+      joueSon: false,
+      joueurSon: new JoueurAudioBuffer()
     };
   },
 
   methods: {
     basculeJoueSon () {
       this.joueSon = !this.joueSon;
+    },
+
+    audioBuffer (idQuestion) {
+      return this.$depotRessources.messageAudio(idQuestion);
     }
   },
 
   watch: {
-    joueSon (val) {
-      if (val) {
-        this.$refs.audio.play();
+    joueSon (joue) {
+      if (joue) {
+        this.joueurSon.start(this.audioBuffer(this.idQuestion), () => { this.joueSon = false; });
       } else {
-        this.$refs.audio.pause();
+        this.joueurSon.stop();
       }
     }
   }

--- a/src/situations/objets_trouves/vues/lecture-message.vue
+++ b/src/situations/objets_trouves/vues/lecture-message.vue
@@ -2,7 +2,7 @@
   <div class="telephone-conteneur">
     <bouton-lecture
        class="bouton-lecture"
-       :son-message="$depotRessources.messageAudio(question.id)"
+       :idQuestion="question.id"
        :class="classPositionBoutonLecture"
     />
   </div>

--- a/tests/situations/commun/aides/mock_chargeurs.js
+++ b/tests/situations/commun/aides/mock_chargeurs.js
@@ -1,5 +1,5 @@
 import MockAudioNode from '../aides/mock_audio_node';
-const chargeurDefaut = (src) => Promise.resolve(() => { return src; });
+export const chargeurDefaut = (src) => Promise.resolve(() => { return src; });
 
 export default function (chargeurs = {}) {
   return {

--- a/tests/situations/commun/vues/lecteur_audio.test.js
+++ b/tests/situations/commun/vues/lecteur_audio.test.js
@@ -2,8 +2,8 @@ import { shallowMount } from '@vue/test-utils';
 import LecteurAudio from 'commun/vues/lecteur_audio';
 
 describe('Le lecteur audio', function () {
-  it('rend une balise audio', function () {
-    const wrapper = shallowMount(LecteurAudio, { propsData: { src: '1', joueSon: false } });
-    expect(wrapper.findAll('audio').length).toBe(1);
+  it("rend l'image d'un haut parleur", function () {
+    const wrapper = shallowMount(LecteurAudio, { propsData: { questionnaire: 'agenda', idReponse: 1, joueSon: false } });
+    expect(wrapper.findAll('svg').length).toBe(1);
   });
 });

--- a/tests/situations/inventaire/aides/mock_depot_ressources.js
+++ b/tests/situations/inventaire/aides/mock_depot_ressources.js
@@ -1,3 +1,5 @@
+import MockAudioNode from '../../commun/aides/mock_audio_node';
+
 export default class MockDepotRessourcesInventaire {
   croixRetourStock () {
     return { src: 'croix' };
@@ -13,5 +15,13 @@ export default class MockDepotRessourcesInventaire {
 
   boutonSaisie () {
     return { src: 'bouton-saisie' };
+  }
+
+  sonEchec () {
+    return new MockAudioNode();
+  }
+
+  sonReussite () {
+    return new MockAudioNode();
   }
 }

--- a/tests/situations/inventaire/vues/formulaire_saisie_inventaire.test.js
+++ b/tests/situations/inventaire/vues/formulaire_saisie_inventaire.test.js
@@ -235,7 +235,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
 
   it("joue l'audio en cas de réussite", function (done) {
     const magasin = unMagasinVide();
-    magasin.audios.reussite.play = done;
+    depotRessources.sonReussite = () => { return { start: done }; };
     initialiseFormulaireSaisieInventaire(magasin, '#magasin', $, journal, depotRessources);
     $('.formulaire-saisie-inventaire .valide-saisie').click();
   });
@@ -247,7 +247,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
       new Contenant({ idContenu: '0', quantite: 12 })
     ).construit();
 
-    magasin.audios.echec.play = done;
+    depotRessources.sonEchec = () => { return { start: done }; };
 
     initialiseFormulaireSaisieInventaire(magasin, '#magasin', $, journal, depotRessources);
     $('.formulaire-saisie-inventaire .valide-saisie').click();

--- a/tests/situations/objets_trouves/infra/depot_ressources_objets_trouves.test.js
+++ b/tests/situations/objets_trouves/infra/depot_ressources_objets_trouves.test.js
@@ -1,4 +1,4 @@
-import chargeurs from '../../commun/aides/mock_chargeurs';
+import chargeurs, { chargeurDefaut } from '../../commun/aides/mock_chargeurs';
 import DepotRessourcesObjetsTrouves from 'objets_trouves/infra/depot_ressources_objets_trouves';
 import sonChoix1 from 'objets_trouves/assets/reponse_jardin_acclimatation.wav';
 import messageMickael from 'objets_trouves/assets/repondeur-message-mickael.wav';
@@ -8,7 +8,7 @@ describe('Le dépot ressource de la situation Objects trouvés', function () {
   let depot;
 
   beforeEach(function () {
-    depot = new DepotRessourcesObjetsTrouves(chargeurs());
+    depot = new DepotRessourcesObjetsTrouves(chargeurs({ wav: chargeurDefaut }));
   });
 
   describe('charge les ressources audio', function () {

--- a/tests/situations/objets_trouves/vues/bouton-lecture.test.js
+++ b/tests/situations/objets_trouves/vues/bouton-lecture.test.js
@@ -1,25 +1,33 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
 import BoutonLecture from 'objets_trouves/vues/bouton-lecture';
 
 describe('Le bouton de lecture de message audio', function () {
-  it('rend une balise audio', function () {
-    const wrapper = shallowMount(BoutonLecture, { propsData: { sonMessage: '1' } });
-    expect(wrapper.findAll('audio').length).toBe(1);
-  });
-
   it("affiche le bouton play quand aucun son n'est joué", function () {
-    const wrapper = shallowMount(BoutonLecture, { propsData: { sonMessage: '1' } });
-    wrapper.vm.joueSon = false;
-    expect(wrapper.findAll('button svg path').at(0).classes('bouton-lecture')).toBe(true);
+    const wrapper = shallowMount(BoutonLecture, { propsData: { idQuestion: '1' } });
+    expect(wrapper.find('.bouton-lecture').exists()).toBe(true);
   });
 
   it('joue le son et affiche le bouton pause', function (done) {
+    const localVue = createLocalVue();
+    localVue.prototype.$depotRessources = {
+      messageAudio: (idQuestion) => {
+        expect(idQuestion).toEqual('question1');
+      }
+    };
+
+    const wrapper = shallowMount(BoutonLecture, {
+      localVue: localVue,
+      propsData: { idQuestion: 'question1', joueSon: true }
+    });
     let sonJoue = false;
-    HTMLMediaElement.prototype.play = () => { sonJoue = true; };
-    const wrapper = shallowMount(BoutonLecture, { propsData: { sonMessage: '1', joueSon: true } });
+    wrapper.vm.joueurSon = {
+      start: () => {
+        sonJoue = true;
+      }
+    };
     wrapper.vm.joueSon = true;
     wrapper.vm.$nextTick(() => {
-      expect(wrapper.findAll('button svg path').at(0).classes('bouton-pause')).toBe(true);
+      expect(wrapper.find('.bouton-pause').exists()).toBe(true);
       expect(sonJoue).toBe(true);
       done();
     });

--- a/tests/situations/objets_trouves/vues/lecture-message.test.js
+++ b/tests/situations/objets_trouves/vues/lecture-message.test.js
@@ -1,30 +1,16 @@
-import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import VueLectureMessage from 'objets_trouves/vues/lecture-message';
-import { creeStore } from 'objets_trouves/modeles/store';
 import BoutonLecture from 'objets_trouves/vues/bouton-lecture';
 
 describe('La lecture de message pour objets trouvés', function () {
   let question;
-  let store;
   let wrapper;
-  let localVue;
-  let idQuestionMessageAudio;
 
   beforeEach(function () {
-    localVue = createLocalVue();
     question = { id: 'message-bureau-mickael' };
-    store = creeStore();
-    localVue.prototype.$depotRessources = {
-      messageAudio: (questionId) => {
-        idQuestionMessageAudio = questionId;
-        return 'chemin ressource audio';
-      }
-    };
 
     wrapper = shallowMount(VueLectureMessage, {
-      propsData: { question },
-      store,
-      localVue
+      propsData: { question }
     });
   });
 
@@ -34,7 +20,7 @@ describe('La lecture de message pour objets trouvés', function () {
   });
 
   it('joue le message audio de la question', function () {
-    expect(idQuestionMessageAudio).toEqual(question.id);
+    expect(wrapper.findComponent(BoutonLecture).props().idQuestion).toBe(question.id);
   });
 
   it('affiche le bouton à la bonne position en fonction de la question', function () {


### PR DESCRIPTION
Cette PR supprime les balises <audio> qui ne marchent pas avec Safari dans notre cas.

Safari est apparemment trop exigent quand aux actions utilisateur nécessaires pour jouer un son. Ce commit généralise l'utilisation de `AudioBufferSourceNode`, encapsulé dans le fichier `joueur_audio_buffer.js`.

https://developer.mozilla.org/fr/docs/Web/Guide/Audio_and_video_delivery
<img width="803" alt="Capture d’écran 2021-08-17 à 15 20 16" src="https://user-images.githubusercontent.com/298214/129760938-709adb5c-68b7-44f6-882a-01066205ebaa.png">

Cette PR améliore aussi les tests avec l'usage d'un `fileTransformer.js` pour transformer les ressources sans perdre le nom du fichier (ceci est nécessaire pour s'assurer qu'on a bien charger la bonne ressource dans certains tests).

Voici les 3 écrans qui ne jouaient pas de son sur Safari :
<img width="1022" alt="Capture d’écran 2021-08-17 à 18 18 32" src="https://user-images.githubusercontent.com/298214/129763392-ebc39bf0-c052-493e-bda6-c14814f87ebf.png">
<img width="1029" alt="Capture d’écran 2021-08-17 à 18 18 51" src="https://user-images.githubusercontent.com/298214/129763399-f0605f2c-21de-4c54-b526-e686cecd5d00.png">
Et sur l'inventaire, on n'entendait pas le "Encore un petit effort" !
<img width="1017" alt="Capture d’écran 2021-08-17 à 18 20 36" src="https://user-images.githubusercontent.com/298214/129763429-753475ca-6035-4b10-9306-c44e6c36af70.png">

