### PR TITLE
Différencie les environnements sur Rollbar

### DIFF
--- a/src/situations/commun/infra/report_erreurs.js
+++ b/src/situations/commun/infra/report_erreurs.js
@@ -5,7 +5,7 @@ const rollbar = new Rollbar({
   captureUncaught: true,
   captureUnhandledRejections: true,
   payload: {
-    environment: process.env.NODE_ENV
+    environment: process.env.ROLLBAR_ENV || process.env.NODE_ENV
   },
   client: {
     javascript: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,7 @@ module.exports = {
     new webpack.EnvironmentPlugin([
       'URL_API',
       'JETON_CLIENT_ROLLBAR',
+      'ROLLBAR_ENV',
       'SOURCE_VERSION',
       'ANNONCE_GENERALE',
       'HOTJAR_ID',


### PR DESCRIPTION
Avant, l'ensemble des erreurs du client était repertorier dans l'environnement 'production'