### PR TITLE
Ne fait plus d'appel réseau au retour à l'accueil

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -104,6 +104,11 @@ export function creeStore (registreUtilisateur, registreCampagne, fetch = window
         const campagne = registreCampagne.recupereCampagneCourante();
         this.state.nomCampagne = campagne.libelle;
 
+        if (!campagne.situations) {
+          commit('deconnecte');
+          return;
+        }
+
         const situations = campagne.situations.map(function (situation, index) {
           return {
             nom: situation.libelle,

--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -100,29 +100,19 @@ export function creeStore (registreUtilisateur, registreCampagne, fetch = window
       deconnecte () {
         return registreUtilisateur.deconnecte();
       },
-      synchroniseEvaluation ({ commit }) {
-        return fetch(registreUtilisateur.urlEvaluation())
-          .then((reponse) => {
-            if (reponse.status === 404) {
-              commit('deconnecte');
-              throw reponse;
-            }
-            return reponse;
-          })
-          .finally((reponse) => {
-            const campagne = registreCampagne.recupereCampagneCourante();
-            this.state.nomCampagne = campagne.libelle;
+      recupereSituations ({ commit }) {
+        const campagne = registreCampagne.recupereCampagneCourante();
+        this.state.nomCampagne = campagne.libelle;
 
-            const situations = campagne.situations.map(function (situation, index) {
-              return {
-                nom: situation.libelle,
-                chemin: `${situation.nom_technique}.html`,
-                identifiant: situation.nom_technique,
-                niveauMinimum: index + 1
-              };
-            });
-            commit('metsAJourSituations', situations);
-          });
+        const situations = campagne.situations.map(function (situation, index) {
+          return {
+            nom: situation.libelle,
+            chemin: `${situation.nom_technique}.html`,
+            identifiant: situation.nom_technique,
+            niveauMinimum: index + 1
+          };
+        });
+        commit('metsAJourSituations', situations);
       },
       termineEvaluation ({ commit }) {
         return fetch(registreUtilisateur.urlEvaluation('fin'), { method: 'POST' })

--- a/src/situations/accueil/vues/accueil.vue
+++ b/src/situations/accueil/vues/accueil.vue
@@ -194,7 +194,7 @@ export default {
   },
 
   mounted () {
-    this.synchroniseEvaluation();
+    this.recupereSituations();
   },
 
   watch: {
@@ -202,7 +202,7 @@ export default {
       if (!this.estConnecte) {
         this.reinitialiseDonnees();
       } else {
-        this.synchroniseEvaluation(false);
+        this.recupereSituations(false);
         this.indexBatiment = 0;
       }
     },
@@ -213,11 +213,11 @@ export default {
   },
 
   methods: {
-    synchroniseEvaluation (sync = true) {
+    recupereSituations (syncIndexBatiment = true) {
       if (!this.estConnecte) return;
-      this.$store.dispatch('synchroniseEvaluation')
+      this.$store.dispatch('recupereSituations')
         .finally(() => {
-          if (sync) {
+          if (syncIndexBatiment) {
             this.indexBatiment = this.niveauMax;
           }
         });

--- a/tests/situations/accueil/modeles/store.test.js
+++ b/tests/situations/accueil/modeles/store.test.js
@@ -107,6 +107,16 @@ describe("Le store de l'accueil", function () {
       });
     });
 
+    it("se déconnecte si la campagne récupérée n'a pas de situation pour forcer rechargement de la campagne", function () {
+      registreUtilisateur.urlEvaluation = () => '/evaluation';
+      registreCampagne.recupereCampagneCourante = () => {
+        return { libelle: 'libellé campagne' };
+      };
+      const store = creeStore(registreUtilisateur, registreCampagne);
+      store.commit('connecte', 'test');
+      return store.dispatch('recupereSituations').then(() => {
+        expect(store.state.estConnecte).toEqual(false);
+      });
     });
   });
 

--- a/tests/situations/accueil/modeles/store.test.js
+++ b/tests/situations/accueil/modeles/store.test.js
@@ -87,37 +87,26 @@ describe("Le store de l'accueil", function () {
     });
   });
 
-  it('sait récupérer les situations depuis le serveur', function () {
-    registreUtilisateur.urlEvaluation = () => '/evaluation';
-    registreCampagne.recupereCampagneCourante = () => {
-      const situation = { nom_technique: 'nom_technique', libelle: 'libelle' };
-      return { situations: [situation], libelle: 'libellé campagne' };
-    };
-    const fetch = (url) => Promise.resolve({
-      json: () => {}
-    });
-    const store = creeStore(registreUtilisateur, registreCampagne, fetch);
-    return store.dispatch('synchroniseEvaluation').then(() => {
-      const situationAttendue = {
-        identifiant: 'nom_technique',
-        nom: 'libelle',
-        chemin: 'nom_technique.html',
-        niveauMinimum: 1
+  describe('Action : recupereSituations', function () {
+    it('sait récupérer les situations avec le registreCampagne', function () {
+      registreUtilisateur.urlEvaluation = () => '/evaluation';
+      registreCampagne.recupereCampagneCourante = () => {
+        const situation = { nom_technique: 'nom_technique', libelle: 'libelle' };
+        return { situations: [situation], libelle: 'libellé campagne' };
       };
-      expect(store.state.nomCampagne).toEqual('libellé campagne');
-      expect(store.state.situations).toEqual([situationAttendue]);
+      const store = creeStore(registreUtilisateur, registreCampagne);
+      return store.dispatch('recupereSituations').then(() => {
+        const situationAttendue = {
+          identifiant: 'nom_technique',
+          nom: 'libelle',
+          chemin: 'nom_technique.html',
+          niveauMinimum: 1
+        };
+        expect(store.state.nomCampagne).toEqual('libellé campagne');
+        expect(store.state.situations).toEqual([situationAttendue]);
+      });
     });
-  });
 
-  it('se déconnecte en cas de 404 du serveur', function () {
-    registreUtilisateur.urlEvaluation = () => '/evaluation';
-    const fetch = (url) => Promise.resolve({
-      status: 404
-    });
-    const store = creeStore(registreUtilisateur, registreCampagne, fetch);
-    store.commit('connecte', 'test');
-    return store.dispatch('synchroniseEvaluation').catch(() => {
-      expect(store.state.estConnecte).toEqual(false);
     });
   });
 
@@ -191,7 +180,7 @@ describe("Le store de l'accueil", function () {
       registreCampagne.assigneCampagneCourante = (codeCampagne) => {};
     });
 
-    describe('quand la campagne est récupérer', function () {
+    describe('quand la campagne est récupérée', function () {
       beforeEach(function () {
         const mockRegistre = { code: { id: 1, nom: 'ma campagne' } };
         registreCampagne.recupereCampagne = (codeCampagne) => {

--- a/tests/situations/accueil/vues/accueil.test.js
+++ b/tests/situations/accueil/vues/accueil.test.js
@@ -133,7 +133,7 @@ describe('La vue accueil', function () {
 
   it("synchronise l'évaluation quand un utilisateur affiche l'accueil en étant connecté", function (done) {
     store.dispatch = (evenement) => {
-      expect(evenement).toEqual('synchroniseEvaluation');
+      expect(evenement).toEqual('recupereSituations');
       done();
       return Promise.resolve();
     };
@@ -147,7 +147,7 @@ describe('La vue accueil', function () {
   it("synchronise l'évaluation à la connexion", function (done) {
     let nombreDispatch = 0;
     store.dispatch = (evenement) => {
-      expect(evenement).toEqual('synchroniseEvaluation');
+      expect(evenement).toEqual('recupereSituations');
       nombreDispatch++;
       return Promise.resolve();
     };
@@ -168,21 +168,6 @@ describe('La vue accueil', function () {
     store.state.estConnecte = true;
     store.state.situationsFaites = [''];
     store.dispatch = () => Promise.resolve();
-    const wrapper = shallowMount(Accueil, {
-      localVue,
-      store
-    });
-
-    wrapper.vm.$nextTick(() => {
-      expect(wrapper.vm.indexBatiment).toBe(2);
-      done();
-    });
-  });
-
-  it('assigne indexBatiment au niveau max même si le chargement des situations à échoué', function (done) {
-    store.state.estConnecte = true;
-    store.state.situationsFaites = [''];
-    store.dispatch = () => Promise.reject(new Error('Pas de réseau'));
     const wrapper = shallowMount(Accueil, {
       localVue,
       store


### PR DESCRIPTION
A la sortie d'une MES on faisait un appel réseau qui historiquement nous permettait de récupérer la liste des MES. Cette appel réseau est maintenant inutile du fait du horsligne et du stockage des campagnes dans le localstorage.