### PR TITLE
Ajoute la condition de l'OS pour detecter si le device est mobile

### DIFF
--- a/src/situations/maintenance/vues/lexique.vue
+++ b/src/situations/maintenance/vues/lexique.vue
@@ -79,7 +79,7 @@ import Touche from './touche';
 import EvenementIdentificationMot from '../modeles/evenement_identification_mot';
 import EvenementApparitionMot from '../modeles/evenement_apparition_mot';
 
-import { isMobile } from 'mobile-device-detect';
+import { isMobile, isIOs, isAndroid } from 'mobile-device-detect';
 
 const DELAI_CROIX = 500;
 
@@ -106,7 +106,7 @@ export default {
       choixFait: null,
       CHOIX_FRANCAIS,
       CHOIX_PASFRANCAIS,
-      estMobile: isMobile
+      estMobile: isMobile || isIOs || isAndroid
     };
   },
 


### PR DESCRIPTION
Certaines tablette ne sont pas identifiés comme mobiles alors on vérifie en plus l'OS

Co-authored-by: Marine Sourin <msourin@captive.fr>
Co-authored-by: Clément Prod'homme <clement@captive.fr>