### PR TITLE
Ajoute un slash à la fin du SCOP_URL

### DIFF
--- a/src/situations/accueil/vues/acces_situation.vue
+++ b/src/situations/accueil/vues/acces_situation.vue
@@ -11,6 +11,7 @@
 </template>
 
 <script>
+import path from 'path';
 import 'accueil/styles/acces_situation.scss';
 import { SCOPE_URL } from 'commun/vues/affiche_situation';
 
@@ -44,7 +45,7 @@ export default {
     cheminSituation () {
       if (!this.situation.chemin) return;
 
-      return `${SCOPE_URL}/${this.situation.chemin}`;
+      return path.join(SCOPE_URL, this.situation.chemin);
     }
 
   }

--- a/src/situations/commun/vues/affiche_situation.js
+++ b/src/situations/commun/vues/affiche_situation.js
@@ -7,7 +7,7 @@ import creeJournalPourSituation from 'commun/modeles/journal';
 import VueCadre from 'commun/vues/cadre';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
-export const SCOPE_URL = '/jeu';
+export const SCOPE_URL = '/jeu/';
 
 export function afficheSituation (identifiantSituation, modeleSituation, VueSituation, depotRessources) {
   function affiche (pointInsertion, $) {


### PR DESCRIPTION
Ceci est necessaire pour que le retour à l'accueil en cas d'abandon
d'une MES redirige bien vers l'url avec un slash à la fin dans le cas du
hors ligne.