### PR TITLE
Retourne les erreurs dans la console JS en environnement de DEV

### DIFF
--- a/src/situations/commun/infra/report_erreurs.js
+++ b/src/situations/commun/infra/report_erreurs.js
@@ -1,7 +1,9 @@
 import Rollbar from 'rollbar';
 
+const rollbarEnabled = !!process.env.JETON_CLIENT_ROLLBAR;
+
 const rollbar = new Rollbar({
-  enabled: !!process.env.JETON_CLIENT_ROLLBAR,
+  enabled: rollbarEnabled,
   accessToken: process.env.JETON_CLIENT_ROLLBAR,
   captureUncaught: true,
   captureUnhandledRejections: true,
@@ -18,7 +20,11 @@ const rollbar = new Rollbar({
 });
 
 export function erreur (...args) {
-  rollbar.error(...args);
+  if (rollbarEnabled) {
+    rollbar.error(...args);
+  } else {
+    console.error(...args);
+  }
 }
 
 function formatComponentName (vm) {


### PR DESCRIPTION
On avait un problème jusque là qui faisait que la console JS ne remontait par les erreurs

Co-authored-by: Étienne Charignon <etienne.charignon@beta.gouv.fr>