### PR TITLE
Permet de stoper un son plusieurs fois sans générer d'erreur

### DIFF
--- a/src/situations/commun/composants/joueur_audio_buffer.js
+++ b/src/situations/commun/composants/joueur_audio_buffer.js
@@ -1,14 +1,15 @@
 export default class JoueurAudioBuffer {
   start (audioBuffer, callbackFin) {
     this.sonEnCours = audioBuffer;
-    audioBuffer.start();
-    this.timeoutId = setTimeout(callbackFin, audioBuffer.buffer.duration * 1000);
+    this.sonEnCours.start();
+    this.timeoutId = setTimeout(callbackFin, this.sonEnCours.buffer.duration * 1000);
   }
 
   stop () {
-    clearTimeout(this.timeoutId);
     if (this.sonEnCours) {
+      clearTimeout(this.timeoutId);
       this.sonEnCours.stop();
+      this.sonEnCours = null;
     }
   }
 }

--- a/tests/situations/commun/composants/joueur_audio_buffer.test.js
+++ b/tests/situations/commun/composants/joueur_audio_buffer.test.js
@@ -2,18 +2,42 @@ import JoueurAudioBuffer from 'commun/composants/joueur_audio_buffer';
 
 describe('Joueur AudioBuffer', function () {
   let joueur;
+  let started = false;
+  let stopCount = 0;
 
   beforeEach(function () {
     joueur = new JoueurAudioBuffer();
+    jest.useFakeTimers('legacy');
   });
 
   afterEach(function () {
     jest.useRealTimers();
   });
 
-  it('peut stoper un buffer non démarré', () => {
-    jest.useFakeTimers('legacy');
+  it('peut stoper un buffer non démarré', function () {
     joueur.stop();
-    expect(clearTimeout).toHaveBeenCalledTimes(1);
+    expect(stopCount).toEqual(0);
+    expect(clearTimeout).toHaveBeenCalledTimes(0);
+  });
+
+  describe('Peut démarrer puis stoper un buffer', function () {
+    beforeEach(function () {
+      joueur.start({
+        start: () => { started = true; },
+        stop: () => { stopCount += 1; },
+        buffer: { duration: 3 }
+      }, () => {});
+    });
+
+    it('peut démarrer un son', function () {
+      expect(started).toBe(true);
+    });
+
+    it('peut stoper deux fois', function () {
+      joueur.stop();
+      joueur.stop();
+      expect(stopCount).toEqual(1);
+      expect(clearTimeout).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
Cela peut arriver si on lit un son entièrement jusqu'au la fin (ce qui
déclence un appel à la fonction stop()) puis qu'on termine la question ce
qui produit un second appel à stop() dans la méthode beforeDestroy()
de bouton_lecture.vue

Appeler deux fois stop() sur un audio buffer déclenche une erreur
InvalidStateError sur certaine version de safari

https://rollbar.com/eva-betagouv/eva/items/463/?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification