### PR TITLE
change légèrement le design de la version dans le footer

### DIFF
--- a/src/public/template_index.html
+++ b/src/public/template_index.html
@@ -55,8 +55,9 @@
     </section>
     <section class='footer chargement-termine'>
       <h2 class='footer-titre'>eva</h2>
-      <div class='footer-contenu'>Le code source <a href="https://github.com/betagouv/eva">est libre</a></div>
-      <div class='footer-contenu'>version <%= process.env.SOURCE_VERSION_COURTE %></div>
+      <div class='footer-contenu'>Le code source <a href="https://github.com/betagouv/eva">est libre</a>
+        <span class='footer-version'> - version <%= process.env.SOURCE_VERSION_COURTE %></span>
+      </div>
     </section>
   </body>
 </html>

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -155,6 +155,10 @@ h3 {
     font-size: 0.9rem;
 
     a { color: $blanc }
+
+    .footer-version {
+      color: $bleu-fonce;
+    }
   }
 }
 


### PR DESCRIPTION
- passe en bleu foncé
- évite d'utiliser la dernière ligne de l'écran qui est parfois
  recouverte par des informations du navigateur
<img width="378" alt="Capture d’écran 2022-01-12 à 10 45 07" src="https://user-images.githubusercontent.com/298214/149113864-9249097c-8084-4a36-a3f6-45ca8a6253ee.png">
