### PR TITLE
DragAndDrop.vue : utiliser data pour l'image…

### DIFF
--- a/src/situations/plan_de_la_ville/vues/components/drag_and_drop.vue
+++ b/src/situations/plan_de_la_ville/vues/components/drag_and_drop.vue
@@ -4,7 +4,7 @@
     >
     <img
       :style="positionMaison"
-      :src="$depotRessources.egliseMaisonAPlacer().src"
+      :src="egliseMaisonAPlacer"
       v-on:mousedown="debuteSelection"
       v-on:mouseup="termineSelection"
       v-on:dragstart.prevent=""
@@ -42,7 +42,8 @@ export default {
       }
     });
     const deplaceur = new DeplaceurPieces(scene.largeur, scene.hauteur);
-    return { piece, emplacementCible, deplaceur };
+    const egliseMaisonAPlacer = this.$depotRessources.egliseMaisonAPlacer().src;
+    return { piece, emplacementCible, deplaceur, egliseMaisonAPlacer };
   },
 
   computed: {


### PR DESCRIPTION
 …pour éviter que vuejs ne fasse un appel réseau

Quand on indique directement l'appel au depotRessource dans le template,
vuejs fait un appel réseau pour retrouver l'image à chaque déplacement
de l'image.