### PR TITLE
Corrige le nouveau chargement des illustrations

### DIFF
--- a/src/situations/commun/infra/depot_ressources_communes.js
+++ b/src/situations/commun/infra/depot_ressources_communes.js
@@ -60,6 +60,9 @@ export default class DepotRessourcesCommunes extends DepotRessources {
   }
   
   trouveIllustrations(configuration) {
+    if (! (configuration instanceof Object)) {
+      return [];
+    }
     let illustrations = [];
     if (Array.isArray(configuration)) {
       configuration.forEach(objet => {
@@ -72,9 +75,7 @@ export default class DepotRessourcesCommunes extends DepotRessources {
         }
       });
       Object.values(configuration).forEach(value => {
-        if (value instanceof Object) {
-          illustrations = illustrations.concat(this.trouveIllustrations(value));
-        }
+        illustrations = illustrations.concat(this.trouveIllustrations(value));
       });
     }
     return illustrations;

--- a/tests/situations/commun/infra/depot_ressources_communes.test.js
+++ b/tests/situations/commun/infra/depot_ressources_communes.test.js
@@ -81,6 +81,7 @@ describe('Le dépot de ressources communes', function () {
       expect(depot.trouveIllustrations({illustration: 'cheming.png', icone: 'icone.png'})).toEqual(['cheming.png', 'icone.png']);
       expect(depot.trouveIllustrations([{illustration: 'cheming.png'}])).toEqual(['cheming.png']);
       expect(depot.trouveIllustrations({chapitre: {illustration: 'cheming.png'}})).toEqual(['cheming.png']);
+      expect(depot.trouveIllustrations(['une liste de string', 'autre string'])).toEqual([]);
     });
 
     it("#chargeIllustrationsConfigurations", function () {


### PR DESCRIPTION
Avec le nouveau déploiement, la situation "objets trouvés" ne pouvais plus démarrer. Cette corrige ce problème

https://rollbar.com/eva-betagouv/eva/items/512/?item_page=0&#traceback