### PR TITLE
ajoute le nom du fichier lors d'une erreur de décodage audio

### DIFF
--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -18,7 +18,10 @@ function chargeurAudio (src) {
             return source;
           });
         },
-        reject);
+        function (erreur) {
+          const message = `Erreur au décodage de ${src} : ${erreur}`;
+          reject(new Error(message));
+        });
     };
   });
 

--- a/tests/situations/commun/infra/depot_ressources.test.js
+++ b/tests/situations/commun/infra/depot_ressources.test.js
@@ -15,12 +15,16 @@ describe('le dépôt de ressources', function () {
   });
 
   it('rejette la promesse lorsque une ressource est en erreur', function (done) {
+    const une_erreur = new Error('cette erreur doit être attrapée et traitée');
     const depot = new DepotRessources({
       mp3: () => Promise.resolve(),
-      png: () => Promise.reject(new Error('test'))
+      png: () => Promise.reject(une_erreur)
     });
     depot.charge(['test.png', 'test.mp3']);
-    depot.chargement().catch(() => done());
+    depot.chargement().catch((erreur) => {
+      expect(erreur).toEqual(une_erreur);
+      done();
+    });
   });
 
   it('sait charger des ressources en plusieurs fois', function () {


### PR DESCRIPTION
J'ai aussi légèrement enrichi un test d'erreur mais ce n'est pas lié au code que j'ai ajouté qui lui n'est pas testé. J'ai fais le test à la main 😞 