### PR TITLE
se déconnecte s'il n'y a pas de campagne courante

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -96,13 +96,12 @@ export function creeStore (registreUtilisateur, registreCampagne) {
       },
       recupereSituations ({ commit }) {
         const campagne = registreCampagne.recupereCampagneCourante();
-        this.state.nomCampagne = campagne.libelle;
-
-        if (!campagne.situations) {
+        if (!campagne || !campagne.situations) {
           commit('deconnecte');
           return;
         }
 
+        this.state.nomCampagne = campagne.libelle;
         const situations = campagne.situations.map(function (situation, index) {
           return {
             nom: situation.libelle,

--- a/tests/situations/accueil/modeles/store.test.js
+++ b/tests/situations/accueil/modeles/store.test.js
@@ -106,6 +106,17 @@ describe("Le store de l'accueil", function () {
         expect(store.state.estConnecte).toEqual(false);
       });
     });
+
+    it("se déconnecte s'il n'y a pas de campagne courrante", function () {
+      registreCampagne.recupereCampagneCourante = () => {
+        return null;
+      };
+      const store = creeStore(registreUtilisateur, registreCampagne);
+      store.commit('connecte', 'test');
+      return store.dispatch('recupereSituations').then(() => {
+        expect(store.state.estConnecte).toEqual(false);
+      });
+    });
   });
 
   describe('Action : terminerEvaluation', function () {


### PR DESCRIPTION
Fix l'erreur rollbar https://rollbar.com/eva-betagouv/eva/items/506/

Pour une raison obscure certains clients n'ont pas de campagne courante.
C'est peut-être qu'ils ont simplement une ancienne version de
l'application, mais ça peut être tout un tas d'autre chose. Bref, pour
éviter d'avoir un plantage, nous forçons ici la déconnexion s'il n'y a
pas de campagne courante.