### PR TITLE
Fixe la couleur de l'affichage du mot cuisine dans le texte à trou

### DIFF
--- a/src/situations/cafe_de_la_place/styles/texte_a_trous.scss
+++ b/src/situations/cafe_de_la_place/styles/texte_a_trous.scss
@@ -38,9 +38,9 @@
       border: 2px dotted $bleu-gris-fonce;
       border-radius: 4px;
     }
-  }
 
-  li .reponse--completee {
-    color: $bleu;
+    &--completee {
+      color: $bleu;
+    }
   }
 }


### PR DESCRIPTION
![Capture d’écran 2022-04-25 à 16 30 07](https://user-images.githubusercontent.com/81169078/165110759-4fcdafb1-2129-4135-a8f8-753e08c82773.png)
