### PR TITLE
retirer la correction automatique sur le champ de saisi

### DIFF
--- a/src/situations/commun/vues/defi/champ_saisie.vue
+++ b/src/situations/commun/vues/defi/champ_saisie.vue
@@ -21,6 +21,10 @@
       <input
           v-on:input="emetReponse($event.target.value)"
           class="champ"
+          spellcheck="false"
+          autocomplete="off"
+          autocapitalize="off"
+          autocorrect="off"
           :class="{ 'champ-texte' : estTexte,
                     'champ-numerique' : estNumerique }"
           :maxlength="maxLength"


### PR DESCRIPTION
Le comportement par défaut des 3 propriétés (autocomplete, autocorrect et spellcheck) est à true.
⚠️ vérifier le comportement du champ de saisi sur tablette