### PR TITLE
Prise en main : empêcher de perdre la maison derrière la consigne

### DIFF
--- a/src/situations/plan_de_la_ville/styles/drag_and_drop.scss
+++ b/src/situations/plan_de_la_ville/styles/drag_and_drop.scss
@@ -6,6 +6,7 @@
 
 .eglise-maison-a-placer {
   position: absolute;
+  z-index: 1;
   top: 355px;
   left: 480px;
   cursor: grab;


### PR DESCRIPTION
Sur tablette, il est très facile de "perdre" la maison derrière la consigne.

En ajoutant un z-index sur la maison, on s'assure que la maison reste devant la consigne et permet ainsi de ne pas la perdre

![Capture d’écran 2022-05-25 à 18 08 57](https://user-images.githubusercontent.com/7428736/170308017-e786c311-4880-4954-8050-f8cac352d7f5.png)
