### PR TITLE
HPar1 : Augmente la taille en hauteur de la zone de dépot

### DIFF
--- a/src/situations/cafe_de_la_place/styles/puzzle.scss
+++ b/src/situations/cafe_de_la_place/styles/puzzle.scss
@@ -13,6 +13,7 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  padding-bottom: 3rem;
 
   .puzzle-item.invisible {
     padding: 0;


### PR DESCRIPTION
 pour correspondre à la maquette

avant : 
<img width="1014" alt="Capture d’écran 2022-06-08 à 11 08 26" src="https://user-images.githubusercontent.com/298214/172578394-49fe9fca-a3f7-4818-a5e9-dea3a6dac082.png">

après : 
<img width="1012" alt="Capture d’écran 2022-06-08 à 11 08 03" src="https://user-images.githubusercontent.com/298214/172578371-6bcf08e2-280a-40bc-90b7-9b458bec5b5f.png">

