### PR TITLE
Ne pas qualifier les questions de compréhention de l'orientation

### DIFF
--- a/src/situations/cafe_de_la_place/data/orientation.js
+++ b/src/situations/cafe_de_la_place/data/orientation.js
@@ -80,7 +80,6 @@ const LOdi2 = {
 const LOdi3 = {
   id: 'LOdi3',
   nom_technique: 'lodi_3',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTele18h55,
   intitule: "18 h 55<br>« Les livres ont la parole ». Quel est le sujet de l’émission ?",
@@ -171,7 +170,6 @@ const LOdi5 = {
 const LOdi6 = {
   id: 'LOdi6',
   nom_technique: 'lodi_6',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Dans quelle ville a été créé le cirque ?",
@@ -203,7 +201,6 @@ const LOdi6 = {
 const LOdi7 = {
   id: 'LOdi7',
   nom_technique: 'lodi_7',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Quel âge a la personne accidentée ?",
@@ -230,7 +227,6 @@ const LOdi7 = {
 const LOdi8 = {
   id: 'LOdi8',
   nom_technique: 'lodi_8',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Charles est-il plus âgé ou plus jeune que Bruno ?",
@@ -257,7 +253,6 @@ const LOdi8 = {
 const LOdi9 = {
   id: 'LOdi9',
   nom_technique: 'lodi_9',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "D’après l’avis du programme télé, s’agit-il d’un film dramatique ou d’un film drôle ?",
@@ -279,7 +274,6 @@ const LOdi9 = {
 const LOdi10 = {
   id: 'LOdi10',
   nom_technique: 'lodi_10',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Ce film est-il poétique, choquant ou érotique ?",
@@ -306,7 +300,6 @@ const LOdi10 = {
 const LOdi11 = {
   id: 'LOdi11',
   nom_technique: 'lodi_11',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "À votre avis, l’image représente-t-elle Charles au début du film ou à la fin du film ?",
@@ -330,7 +323,6 @@ const LOdi11 = {
 const LOdi12 = {
   id: 'LOdi12',
   nom_technique: 'lodi_12',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Pourquoi Charles est-il devenu clown dans le cirque ?",
@@ -360,7 +352,6 @@ const LOdi12 = {
 const LOdi13 = {
   id: 'LOdi13',
   nom_technique: 'lodi_13',
-  metacompetence: 'comprehention',
   type: 'qcm',
   illustration: programmeTeleZoom,
   intitule: "Lisez ces affirmations. Laquelle correspond à l’histoire du film ?",


### PR DESCRIPTION
Pour éviter que ces questions ne soient prise en compte dans le calcul
du profile de compréhention.