### PR TITLE
Ajoute les scores de production de texte

### DIFF
--- a/src/situations/cafe_de_la_place/data/parcours_bas.js
+++ b/src/situations/cafe_de_la_place/data/parcours_bas.js
@@ -654,7 +654,8 @@ const APlc1 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'cuisine',
-    texte: 'cuisine'
+    textes: ['cuisine', 'cuisines'],
+    scores: [1, 0.75]
   }
 };
 
@@ -669,7 +670,8 @@ const APlc2 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'saladiers',
-    texte: 'saladiers'
+    textes: ['saladier', 'saladiers'],
+    scores: [1, 1.25]
   }
 };
 
@@ -684,7 +686,8 @@ const APlc3 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'verre',
-    texte: 'verre'
+    textes: ['verre', 'verres'],
+    scores: [1, 0.75]
   }
 };
 
@@ -699,7 +702,8 @@ const APlc4 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'mayonnaise',
-    texte: 'mayonnaise'
+    textes: ['mayonnaise', 'mayonnaises'],
+    scores: [1, 0.75]
   }
 };
 
@@ -714,7 +718,8 @@ const APlc5 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'sel',
-    texte: 'sel'
+    textes: ['sel', 'sels'],
+    scores: [1, 0.75]
   }
 };
 
@@ -729,7 +734,8 @@ const APlc6 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'tomates',
-    texte: 'tomates'
+    textes: ['tomate', 'tomates'],
+    scores: [1, 1.25]
   }
 };
 
@@ -744,7 +750,8 @@ const APlc7 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'pays',
-    texte: 'pays'
+    textes: ['pays'],
+    scores: [1]
   }
 };
 
@@ -759,7 +766,8 @@ const APlc8 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'poivrons',
-    texte: 'poivrons'
+    textes: ['poivron', 'poivrons'],
+    scores: [1, 1.25]
   }
 };
 
@@ -774,7 +782,10 @@ const APlc9 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'epices',
-    texte: 'épices'
+    textes: ['épice', 'epice', 'èpice', 'êpice', 'ëpice',
+      'épices', 'epices', 'èpices', 'êpices', 'ëpices'],
+    scores: [1, 0.75, 0.75, 0.75, 0.75,
+      1.25, 1, 1, 1, 1]
   }
 };
 
@@ -789,7 +800,8 @@ const APlc10 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'donnent',
-    texte: 'donnent'
+    textes: ['donne', 'donnent'],
+    scores: [1, 1.25]
   }
 };
 
@@ -804,7 +816,8 @@ const APlc11 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'douzaines',
-    texte: 'douzaines'
+    textes: ['douzaine', 'douzaines'],
+    scores: [1, 1.25]
   }
 };
 
@@ -819,7 +832,8 @@ const APlc12 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'assiettes',
-    texte: 'assiettes'
+    textes: ['assiette', 'assiettes'],
+    scores: [1, 1.25]
   }
 };
 
@@ -834,7 +848,8 @@ const APlc13 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'fouets',
-    texte: 'fouets'
+    textes: ['fouet', 'fouets'],
+    scores: [1, 1.25]
   }
 };
 
@@ -849,7 +864,8 @@ const APlc14 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'louche',
-    texte: 'louche'
+    textes: ['louche', 'louches'],
+    scores: [1, 0.75]
   }
 };
 
@@ -864,7 +880,8 @@ const APlc15 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'passoire',
-    texte: 'passoire'
+    textes: ['passoire', 'passoires'],
+    scores: [1, 0.75]
   }
 };
 
@@ -879,7 +896,10 @@ const APlc16 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'poele',
-    texte: 'poêle'
+    textes: ['poêle', 'poele', 'poéle', 'poèle', 'poële',
+      'poêles', 'poeles', 'poéles', 'poèles', 'poëles'],
+    scores: [1, 0.75, 0.75, 0.75, 0.75,
+      0.75, 0.75, 0.75, 0.75, 0.75]
   }
 };
 
@@ -894,7 +914,8 @@ const APlc17 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'luxe',
-    texte: 'luxe'
+    textes: ['luxe', 'luxes'],
+    scores: [1, 0.75]
   }
 };
 
@@ -909,7 +930,8 @@ const APlc18 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'casserole',
-    texte: 'casserole'
+    textes: ['casserole', 'casseroles'],
+    scores: [1, 0.75]
   }
 };
 
@@ -924,7 +946,8 @@ const APlc19 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'adhere',
-    texte: 'adhère'
+    textes: ['adhère', 'adhere', 'adhére', 'adhêre', 'adhëre'],
+    scores: [1, 0.75, 0.75, 0.75, 0.75]
   }
 };
 
@@ -939,7 +962,8 @@ const APlc20 = {
   placeholder: 'Réponse',
   reponse: {
     nom_technique: 'alcoolique',
-    texte: 'alcoolique'
+    textes: ['alcoolique', 'alcooliques'],
+    scores: [1, 0.75]
   }
 };
 

--- a/src/situations/commun/vues/defi/champ_saisie.vue
+++ b/src/situations/commun/vues/defi/champ_saisie.vue
@@ -60,7 +60,10 @@ export default {
   methods: {
     emetReponse (valeur) {
       const reponse = valeur.trim();
-      this.$emit('input', { reponse: reponse, succes: reponse.toLowerCase() === this.question.reponse.texte });
+      const indexReponse = this.question.reponse.textes.indexOf(reponse.toLowerCase());
+      const succes = indexReponse != -1;
+      const score = this.question.reponse.scores && this.question.reponse.scores[indexReponse];
+      this.$emit('input', { reponse, succes, score });
     }
   }
 };

--- a/src/situations/objets_trouves/data/apps.js
+++ b/src/situations/objets_trouves/data/apps.js
@@ -100,7 +100,7 @@ const questionDeverrouillage = {
   intitule: 'Quel est le mot de passe ?',
   extensionVue: 'ecran-telephone-deverrouillage',
   reponse: {
-    texte: '1800'
+    textes: ['1800']
   },
   metacompetence: 'numeratie'
 };
@@ -452,7 +452,7 @@ const questionRepondeur2 = {
   intitule: 'Que sophie devrait-elle répondre ?',
   extensionVue: 'lecture-message',
   reponse: {
-    texte: '21'
+    textes: ['21']
   },
   metacompetence: 'numeratie'
 };

--- a/src/situations/plan_de_la_ville/data/defis.js
+++ b/src/situations/plan_de_la_ville/data/defis.js
@@ -78,7 +78,7 @@ const saisieBoulangerie = {
   sous_type: 'texte',
   placeholder: 'Réponse',
   reponse: {
-    texte: 'boulangerie'
+    textes: ['boulangerie']
   },
   illustration: SaisieBoulangerie,
   intitule: 'Recopiez le nom « Boulangerie » dans le cadre de texte ci-dessous, puis cliquez sur « Valider »'

--- a/tests/situations/commun/vues/defi/champ_saisie.test.js
+++ b/tests/situations/commun/vues/defi/champ_saisie.test.js
@@ -41,11 +41,46 @@ describe('Le composant champ de saisie', function () {
 
   describe('peut être utilisé avec la propriété v-model', function () {
     it('envoie la réponse dans un événement input', function () {
-      vue = composant({ question: { reponse: { texte: 'boulangerie' } } });
+      vue = composant({ question: { reponse: { textes: ['boulangerie'] } } });
       const input = vue.find('input[type=text]');
       input.setValue('Boulangerie ');
       expect(vue.emitted('input').length).toEqual(1);
       expect(vue.emitted('input')[0][0]).toEqual({ reponse: 'Boulangerie', succes: true });
+    });
+  });
+
+  describe('#emetReponse', function() {
+    beforeEach(function() {
+      vue = composant({ question: { reponse: {
+        textes: ['boulangerie', 'boulangeries'],
+        scores: [1, 1.5]
+      } } });
+    });
+
+    it("echoue si la réponse n'est pas dans la liste", function() {
+      vue.vm.emetReponse('boulangery');
+      expect(vue.emitted('input')[0][0]).toEqual({
+        reponse: 'boulangery',
+        succes: false
+      });
+    });
+
+    it("accepte la première réponse", function() {
+      vue.vm.emetReponse('boulangerie');
+      expect(vue.emitted('input')[0][0]).toEqual({
+        reponse: 'boulangerie',
+        succes: true,
+        score: 1
+      });
+    });
+
+    it("accepte la seconde réponse", function() {
+      vue.vm.emetReponse('boulangeries');
+      expect(vue.emitted('input')[0][0]).toEqual({
+        reponse: 'boulangeries',
+        succes: true,
+        score: 1.5
+      });
     });
   });
 


### PR DESCRIPTION
La valeur des scores sera peut-être à ajuster car le travail de
définition est encore en cours. Je me suis basé sur les informations qui
étaient définies jusqu'a présent, qui sont suffisante pour pouvoir
démontrer qu'on calcule bien le profile de production coté serveur.

On permet maintenant à `champ_saisie` d'accepter plusieurs réponses et de donner un score différent à chaque réponse.