### PR TITLE
Ne fait pas d'erreur si le localStorage n'est pas disponible

### DIFF
--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -95,12 +95,14 @@ export default class RegistreUtilisateur extends BaseRegistre {
     this.enregistreEnLocale(this.clePourLocalStorage(idClient), data);
   }
 
-  listeEvaluationsLocales () {
-    return Object.keys(window.localStorage)
+  listeEvaluationsLocales (stockageLocal = window.localStorage) {
+    if(!stockageLocal) { return {}; }
+
+    return Object.keys(stockageLocal)
       .filter((k) => k.startsWith(PREFIX_EVALUATIONS))
       .reduce((liste, k) => {
         const idClient = k.replace(PREFIX_EVALUATIONS, '');
-        return { ...liste, [idClient]: JSON.parse(window.localStorage.getItem(k)) };
+        return { ...liste, [idClient]: JSON.parse(stockageLocal.getItem(k)) };
       }, {});
   }
 

--- a/tests/situations/commun/infra/registre_utilisateur.test.js
+++ b/tests/situations/commun/infra/registre_utilisateur.test.js
@@ -268,6 +268,10 @@ describe('le registre utilisateur', function () {
         2: { id: 2 }
       });
     });
+
+    it('quand window.localStorage est null', function() {
+      expect(registre.listeEvaluationsLocales(null)).toEqual({});
+    });
   });
 
   describe('#deconnecte()', function () {


### PR DESCRIPTION
## ❌ Comportement observé 
TypeError: null is not an object (evaluating 'Object.keys(window.localStorage)')
dans `src/situations/commun/infra/registre_utilisateur.js` line 99 

## ✅ Comportement voulu 
ne pas faire d'erreur à cet endroit si le localstorage n'est pas disponible.

## ℹ️ Aides pour comprendre 
_Exemple : screenshot, vidéo, scénario pour reproduire_

* https://rollbar.com/eva-betagouv/eva/items/584/