### PR TITLE
Ajout du focus si le navigateur est firefox

### DIFF
--- a/src/situations/commun/vues/defi/champ_saisie.vue
+++ b/src/situations/commun/vues/defi/champ_saisie.vue
@@ -14,6 +14,7 @@
       </div>
       <input
           v-on:input="emetReponse($event.target.value)"
+          id="reponsecafedelaplace"
           class="champ"
           spellcheck="false"
           autocomplete="off"
@@ -68,12 +69,23 @@ export default {
   },
 
   methods: {
+    focusInput() {
+      var reponsecafedelaplace = document.getElementById('reponsecafedelaplace');
+      reponsecafedelaplace.focus({ preventScroll: true });
+    },
+
     emetReponse (valeur) {
       const reponse = valeur.trim();
       const indexReponse = this.question.reponse.textes.indexOf(reponse.toLowerCase());
       const succes = indexReponse != -1;
       const score = this.question.reponse.scores && this.question.reponse.scores[indexReponse];
       this.$emit('input', { reponse, succes, score });
+    },
+  },
+
+  mounted: function () {
+    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
+      this.focusInput();
     }
   }
 };

--- a/src/situations/commun/vues/defi/champ_saisie.vue
+++ b/src/situations/commun/vues/defi/champ_saisie.vue
@@ -41,6 +41,10 @@ export default {
     question: {
       type: Object,
       required: true
+    },
+    estFirefox: {
+      type: Boolean,
+      default: isFirefox
     }
   },
 
@@ -80,7 +84,7 @@ export default {
   },
 
   mounted: function () {
-    if (isFirefox) {
+    if (this.estFirefox) {
       this.$refs.reponseCafeDeLaPlace.focus({ preventScroll: true });
     }
   }

--- a/src/situations/commun/vues/defi/champ_saisie.vue
+++ b/src/situations/commun/vues/defi/champ_saisie.vue
@@ -14,7 +14,7 @@
       </div>
       <input
           v-on:input="emetReponse($event.target.value)"
-          id="reponsecafedelaplace"
+          ref="reponseCafeDeLaPlace"
           class="champ"
           spellcheck="false"
           autocomplete="off"
@@ -32,6 +32,7 @@
 </template>
 
 <script>
+import { isFirefox } from 'mobile-device-detect';
 import 'commun/styles/champ.scss';
 import 'commun/styles/defi/champ_saisie.scss';
 
@@ -69,11 +70,6 @@ export default {
   },
 
   methods: {
-    focusInput() {
-      var reponsecafedelaplace = document.getElementById('reponsecafedelaplace');
-      reponsecafedelaplace.focus({ preventScroll: true });
-    },
-
     emetReponse (valeur) {
       const reponse = valeur.trim();
       const indexReponse = this.question.reponse.textes.indexOf(reponse.toLowerCase());
@@ -84,8 +80,8 @@ export default {
   },
 
   mounted: function () {
-    if (navigator.userAgent.toLowerCase().indexOf('firefox') > -1) {
-      this.focusInput();
+    if (isFirefox) {
+      this.$refs.reponseCafeDeLaPlace.focus({ preventScroll: true });
     }
   }
 };

--- a/tests/situations/commun/vues/defi/champ_saisie.test.js
+++ b/tests/situations/commun/vues/defi/champ_saisie.test.js
@@ -26,6 +26,7 @@ describe('Le composant champ de saisie', function () {
     return shallowMount(ChampSaisie, {
       localVue,
       propsData: props,
+      attachTo: document.body,
       stubs: {
         'bouton-lecture': BoutonLectureStub
       }
@@ -162,5 +163,20 @@ describe('Le composant champ de saisie', function () {
       vue = composant({ question: { nom_technique: 'question-sans-audio' } });
       expect(vue.find('.defi-champ-saisie--decale').exists()).toBe(false);
     });
+  });
+
+  describe("met le focus sur l'input au démarrage", function() {
+    it("quand on est sur firefox", function() {
+      vue = composant({ question: { nom_technique: 'question' }, estFirefox: true });
+      const input = vue.find('input[type=text]');
+      expect(document.activeElement).toBe(input.element);
+    });
+
+    it("sur les autres navigateurs", function() {
+      vue = composant({ question: { nom_technique: 'question' } });
+      const input = vue.find('input[type=text]');
+      expect(input.attributes('autofocus')).toBe("autofocus");
+    });
+
   });
 });


### PR DESCRIPTION
`autofocus` en css ne marche pas avec firefox sur `/jeu/cafe_de_la_place.html#HPfb1`

### Avant : 
Pas de focus sur le champ texte sur firefox

### Après : 
Si on est sur firefox, on utilise `.focus()` en javascript sur le champ texte. 


### Note :
[preventScroll](https://developer.mozilla.org/fr/docs/Web/API/HTMLElement/focus) ne marche pas sur safari. Cela donne un interêt d'utiliser `.focus()` uniquement sur firefox. Et de laisser `autofocus` fonctionner autrement.