### PR TITLE
l'outline sur des bords arrondis n'est pas suporté par Safari

### DIFF
--- a/src/situations/commun/styles/defi/champ_saisie.scss
+++ b/src/situations/commun/styles/defi/champ_saisie.scss
@@ -26,7 +26,8 @@
 
   .champ-texte {
     &:focus {
-      outline: 3px solid $bleu;
+      border: 3px solid $bleu;
+      outline: none; // outline sur des bords arrondis n'est pas suporté par Safari
     }
   }
 


### PR DESCRIPTION
### avant 
<img width="1019" alt="Capture d’écran 2022-08-10 à 12 17 38" src="https://user-images.githubusercontent.com/298214/183877554-78e6164e-b000-423e-a6df-897c1caf3e02.png">

### après
<img width="1016" alt="Capture d’écran 2022-08-10 à 12 16 47" src="https://user-images.githubusercontent.com/298214/183877580-7066518a-746d-4ff0-8c3b-e86e665cb1d5.png">

