### PR TITLE
fix affichage de la sous consigne d'hpfb avec la première partie du texte

### DIFF
--- a/src/situations/cafe_de_la_place/data/parcours_haut.js
+++ b/src/situations/cafe_de_la_place/data/parcours_haut.js
@@ -322,6 +322,7 @@ const sousConsigneHPfb2 = {
   nom_technique: 'sous_consigne_HPfb_2',
   type: 'sous-consigne',
   extensionVue: 'email_HPfb_a_trous',
+  numero_page: 1,
   illustration: telephoneEMail,
   intitule: "Vous avez commencé à écrire un message un peu plus tôt, vous devez maintenant le compléter. Je vais vous lire les mots qui manquent, alors écoutez bien !<br><br>Soyez attentifs, certains mots doivent être mis au pluriel, et les verbes doivent être conjugués.<br><br>Si vous ne savez pas comment écrire certains mots, écrivez-les comme vous le pensez et continuez.",
   modalite_reponse: "Pour commencer, cliquez sur « Suivant »."


### PR DESCRIPTION
<img width="1024" alt="Capture d’écran 2022-08-12 à 14 28 06" src="https://user-images.githubusercontent.com/298214/184354097-5be2ccef-fb35-4584-877f-c0b6b5787554.png">

