### PR TITLE
💄 Réduit la hauteur de la barre d'actions

### DIFF
--- a/src/situations/commun/styles/actions.scss
+++ b/src/situations/commun/styles/actions.scss
@@ -1,13 +1,14 @@
 @import "commun/styles/variables.scss";
 
 .actions {
-  height: 6.5rem;
   background: $couleur-fond-actions;
-  padding: 1rem;
-  display: grid;
-  grid-template-columns: 30% 40% 30%;
+  padding: .375rem;
+  display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  gap: 2rem;
+  font-size: .75rem;
+  font-weight: 400;
 
   > :nth-child(2) {
     justify-self: center;
@@ -15,5 +16,11 @@
 
   > :last-child {
     justify-self: end;
+  }
+
+  .bouton-arrondi {
+    line-height: 1;
+    padding: 0.3125rem 1rem;
+    font-size: .75rem;
   }
 }

--- a/src/situations/commun/styles/boutons.scss
+++ b/src/situations/commun/styles/boutons.scss
@@ -78,24 +78,19 @@
 }
 
 .bouton-lecture-en-cours {
-  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, 3rem);
+  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu);
   cursor: default;
 }
 
 .bouton-et-etiquette {
   display: flex;
+  gap: .625rem;
   align-items: center;
+  color: $couleur-texte;
 
   &.gauche {
     flex-direction: row-reverse;
     text-align: right;
-  }
-
-  span {
-    color: $couleur-texte;
-    font-size: 1.1rem;
-    margin-left: 1rem;
-    margin-right: 1rem;
   }
 
   &.desactivee span {
@@ -109,9 +104,7 @@
   }
 
   &:not(.desactivee) {
-    span {
-      cursor: pointer;
-    }
+    cursor: pointer;
   }
 }
 

--- a/src/situations/commun/styles/conteneur.scss
+++ b/src/situations/commun/styles/conteneur.scss
@@ -6,6 +6,6 @@
   @include bords-arrondis;
   @include conteneur;
   @include ombre;
-  height: 41.875rem;
+  height: 37.675rem;
   flex-shrink: 0;
 }

--- a/src/situations/commun/styles/mixins/boutons.scss
+++ b/src/situations/commun/styles/mixins/boutons.scss
@@ -1,8 +1,8 @@
-@mixin bouton($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc, $hauteur-image: 1rem) {
+@mixin bouton($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc, $hauteur-image: .625rem) {
   border-radius: 3.125rem;
   cursor: pointer;
-  height: 3rem;
-  width: 3rem;
+  height: 1.5rem;
+  width: 1.5rem;
   background-color: $couleur-fond;
   display: flex;
   align-items: center;
@@ -27,11 +27,13 @@
     position: relative;
     margin: auto;
     height: $hauteur-image;
+    width: $hauteur-image;
   }
 
   svg {
     margin: auto;
     height: $hauteur-image;
+    width: $hauteur-image;
   }
 }
 

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -17,7 +17,7 @@ export default class VueStop {
   }
 
   affiche (pointInsertion, $) {
-    const boutonStop = new VueBouton('bouton-stop', stop, () => { this.clickSurStop($(pointInsertion).parent(), $); });
+    const boutonStop = new VueBouton('bouton-stop', stop, () => { this.clickSurStop($('#cadre'), $); });
     boutonStop.ajouteUneEtiquette(traduction('situation.abandonner_situation'));
     boutonStop.affiche(pointInsertion, $);
   }

--- a/tests/situations/commun/vues/stop.test.js
+++ b/tests/situations/commun/vues/stop.test.js
@@ -10,7 +10,7 @@ describe('vue Stop', function () {
   let situation;
 
   beforeEach(function () {
-    $('body').append('<div id="point-insertion"></div>');
+    $('body').append('<div id="cadre"><div id="point-insertion"></div></div>');
     mockJournal = {
       enregistre () {}
     };


### PR DESCRIPTION
20% des évalués utilisent une résolution de 1366x768.
Ils doivent scroller pour utiliser le jeu, on peut qu'il n'ait plus besoin de scroller.

On a modifié la barre suivant la maquette présente sur Figma.
Le bouton principal pour entrer dans une situation n'était pas présent sur la maquette, j'ai donc adapté au mieux.

On a fait en sorte que la popup de confirmation de sortie d'une situation ne soit pas placé dans le bloc `.actions` mais dans le bloc `#cadre` afin d'éviter un héritage css un peu bizarre.

Co-authored-by: Marine Dominé <marine@captive.fr>

![Capture d’écran 2022-08-17 à 15 43 51](https://user-images.githubusercontent.com/7428736/185151681-94f1ccc4-53ba-4f50-8d75-5dc82c4244cb.png)
![Capture d’écran 2022-08-17 à 15 44 10](https://user-images.githubusercontent.com/7428736/185151699-9664511b-e0bd-4ce1-a889-5303463c02f3.png)
![Capture d’écran 2022-08-17 à 15 44 21](https://user-images.githubusercontent.com/7428736/185151711-8d128985-484d-468b-9f18-21e67a51165b.png)
