### PR TITLE
Affiche message d'erreur non bloquant pour l'utilisation d'un smartphone

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -183,6 +183,12 @@
       "description": "Votre navigateur ou votre appareil ne semble pas compatible avec la lecture des sons au format mp3.",
       "action": "Veuillez contacter la personne qui vous accompagne."
     },
+    "erreur_utilisation_smartphone": {
+      "titre": "Attention, eva ne doit pas être utilisé sur smartphone !",
+      "description": "Si vous utilisez eva sur un smartphone, vos résultats pourront être faussés.",
+      "action": "Utilisez plutôt un ordinateur ou une tablette.",
+      "bouton": "Ignorer"
+    },
     "chargement": "Chargement en cours",
     "enregistrement": "Enregistrement en cours",
     "go": "Vous pouvez commencer",

--- a/src/situations/accueil/vues/index.vue
+++ b/src/situations/accueil/vues/index.vue
@@ -1,14 +1,30 @@
 <template>
   <div id="accueil">
     <div
+      v-if="estMobile && afficheErreurMobile && !estConnecte && !evaluationTerminee"
+      class="conteneur"
+      style="position: absolute;"
+    >
+      <overlay-erreur
+        :titre="$traduction('situation.erreur_utilisation_smartphone.titre')"
+        :description="$traduction('situation.erreur_utilisation_smartphone.description')"
+        :action="$traduction('situation.erreur_utilisation_smartphone.action')"
+        :boutonIgnorer="true"
+        @ignoreErreur="afficheErreurMobile = false"/>
+    </div>
+    <div
       v-if="chargement || erreurChargement || erreurLectureSon"
       class="conteneur"
     >
-      <overlay-erreur-lecture-son v-if="erreurLectureSon" />
+      <overlay-erreur
+        v-if="erreurLectureSon"
+        :titre="$traduction('situation.erreur_lecture_son.titre')"
+        :description="$traduction('situation.erreur_lecture_son.description')"
+        :action="$traduction('situation.erreur_lecture_son.action')" />
       <overlay-erreur-chargement v-else-if="erreurChargement" />
       <overlay-attente v-else raison='chargement' />
     </div>
-    <accueil :force-campagne="forceCampagne" :force-nom="forceNom" v-else />
+    <accueil :force-campagne="forceCampagne" :force-nom="forceNom" v-else style="z-index: 0;"/>
   </div>
 </template>
 
@@ -16,11 +32,13 @@
 import queryString from 'query-string';
 import OverlayAttente from 'commun/vues/overlay_attente';
 import OverlayErreurChargement from 'commun/vues/overlay_erreur_chargement';
-import OverlayErreurLectureSon from 'accueil/vues/overlay_erreur_lecture_son';
+import OverlayErreur from 'accueil/vues/overlay_erreur';
 import Accueil from './accueil';
+import { estMobile } from 'commun/helpers/mobile';
+import { mapState } from 'vuex';
 
 export default {
-  components: { Accueil, OverlayAttente, OverlayErreurChargement, OverlayErreurLectureSon },
+  components: { Accueil, OverlayAttente, OverlayErreurChargement, OverlayErreur },
 
   data () {
     const parametresUrl = queryString.parse(location.search);
@@ -30,11 +48,20 @@ export default {
       erreurChargement: false,
       erreurLectureSon: false,
       forceCampagne: parametresUrl.code || '',
-      forceNom: parametresUrl.nom || ''
+      forceNom: parametresUrl.nom || '',
+      estMobile: estMobile,
+      afficheErreurMobile: false
     };
   },
 
+  computed: {
+    ...mapState(['estConnecte', 'evaluationTerminee'])
+  },
+
   mounted () {
+    if(this.estMobile) {
+      this.afficheErreurMobile = true;
+    }
     this.$depotRessources.chargement().then(() => {
       this.chargement = false;
     }).catch((erreur) => {

--- a/src/situations/accueil/vues/overlay_erreur.vue
+++ b/src/situations/accueil/vues/overlay_erreur.vue
@@ -1,12 +1,19 @@
 <template>
-  <div class="overlay modale">
+  <div class="overlay modale modale--opaque">
     <div class="modale-interieur">
       <h2 class="titre-avec-illustration">
         <svg width="80" height="72" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M37.16 26.99c0-.835.27-1.54.808-2.117.537-.546 1.217-.818 2.04-.818.822 0 1.502.272 2.04.817.538.578.806 1.283.806 2.117v19.869c0 .834-.268 1.523-.806 2.068-.538.578-1.218.866-2.04.866-.823 0-1.503-.288-2.04-.866-.538-.545-.807-1.234-.807-2.068V26.989Zm2.895 25.93c1.076 0 1.835.176 2.278.529.443.352.664.978.664 1.876v.914c0 .898-.237 1.523-.712 1.876-.474.353-1.233.53-2.277.53-1.107 0-1.882-.177-2.325-.53-.443-.353-.664-.978-.664-1.876v-.914c0-.93.237-1.572.711-1.925.443-.32 1.218-.48 2.325-.48Z" fill="#1E416A"/><path fill-rule="evenodd" clip-rule="evenodd" d="M74.927 63.6 42.054 6a2.359 2.359 0 0 0-4.108 0L5.073 63.6c-.913 1.6.228 3.6 2.055 3.6h65.744c1.827 0 2.968-2 2.055-3.6Zm-28.763-60c-2.74-4.8-9.588-4.8-12.328 0L.964 61.2C-1.776 66 1.65 72 7.128 72h65.744c5.479 0 8.903-6 6.164-10.8L46.164 3.6Z" fill="#1E416A"/></svg>
-        <div class="etiquette-titre">{{ $traduction('situation.erreur_lecture_son.titre') }}</div>
+        <div class="etiquette-titre">{{ titre }}</div>
       </h2>
-      <div>{{ $traduction('situation.erreur_lecture_son.description') }}</div>
-      <div class="overlay-recommandation">{{ $traduction('situation.erreur_lecture_son.action') }}</div>
+      <div>{{ description }}</div>
+      <div class="overlay-recommandation">{{ action }}</div>
+      <button
+        v-if="boutonIgnorer"
+        class="bouton-arrondi"
+        style="margin-top: 32px;"
+        @click="$emit('ignoreErreur')">
+        {{ $traduction('situation.erreur_utilisation_smartphone.bouton') }}
+      </button>
     </div>
   </div>
 </template>
@@ -15,5 +22,23 @@
 import 'commun/styles/overlay.scss';
 
 export default {
+  props: {
+    titre: {
+      type: String,
+      required: true
+    },
+    description: {
+      type: String,
+      required: true
+    },
+    action: {
+      type: String,
+      required: true
+    },
+    boutonIgnorer: {
+      type: Boolean,
+      required: false
+    }
+  }
 };
 </script>

--- a/src/situations/commun/styles/modale.scss
+++ b/src/situations/commun/styles/modale.scss
@@ -18,6 +18,10 @@
     background: rgba(255, 255, 255, .9);
     padding: 3%;
 
+    &--opaque {
+      background: white;
+    }
+
     &.centrage-horizontal {
       flex-direction: column;
       padding: 5%;

--- a/tests/situations/accueil/vues/index.test.js
+++ b/tests/situations/accueil/vues/index.test.js
@@ -2,9 +2,10 @@ import { shallowMount, createLocalVue } from '@vue/test-utils';
 import Index from 'accueil/vues/index';
 import OverlayAttente from 'commun/vues/overlay_attente';
 import OverlayErreurChargement from 'commun/vues/overlay_erreur_chargement';
-import OverlayErreurLectureSon from 'accueil/vues/overlay_erreur_lecture_son';
+import OverlayErreur from 'accueil/vues/overlay_erreur';
 import Accueil from 'accueil/vues/accueil';
 import { traduction } from 'commun/infra/internationalisation';
+import Vuex from 'vuex';
 
 describe('La vue index', function () {
   let depotRessources;
@@ -98,7 +99,8 @@ describe('La vue index', function () {
         expect(wrapper.findComponent(Accueil).exists()).toBe(false);
         expect(wrapper.findComponent(OverlayAttente).exists()).toBe(false);
         expect(wrapper.findComponent(OverlayErreurChargement).exists()).toBe(false);
-        expect(wrapper.findComponent(OverlayErreurLectureSon).exists()).toBe(true);
+        expect(wrapper.findComponent(OverlayErreur).exists()).toBe(true);
+        expect(wrapper.findComponent(OverlayErreur).props('titre')).toBe('situation.erreur_lecture_son.titre');
         expect(consoleError).not.toHaveBeenCalled();
       });
     });
@@ -113,8 +115,34 @@ describe('La vue index', function () {
       });
 
       it('affiche la vue erreur lecture son impossible', function () {
-        expect(wrapper.findComponent(OverlayErreurLectureSon).exists()).toBe(true);
-        expect(consoleError).not.toHaveBeenCalled();
+        expect(wrapper.findComponent(OverlayErreur).exists()).toBe(true);
+        expect(wrapper.findComponent(OverlayErreur).props('titre')).toBe('situation.erreur_lecture_son.titre');
+      });
+    });
+
+    describe("quand la passation est faite sur smartphone", function() {
+      beforeEach(function () {
+        const store = new Vuex.Store({
+          state: {
+            estConnecte: false,
+            evaluationTerminee: false
+          }
+        });
+        wrapper = shallowMount(Index, {
+          localVue,
+          store,
+          data() {
+            return {
+              estMobile: true
+            };
+          }
+        });
+      });
+
+      it("affiche la vue erreur utilisation d'un smartphone", function () {
+        expect(wrapper.vm.afficheErreurMobile).toBe(true);
+        expect(wrapper.findComponent(OverlayErreur).exists()).toBe(true);
+        expect(wrapper.findComponent(OverlayErreur).props('titre')).toBe('situation.erreur_utilisation_smartphone.titre');
       });
     });
   });

--- a/tests/situations/accueil/vues/overlay_erreur.test.js
+++ b/tests/situations/accueil/vues/overlay_erreur.test.js
@@ -1,0 +1,39 @@
+import OverlayErreur from 'accueil/vues/overlay_erreur';
+import { shallowMount, createLocalVue } from '@vue/test-utils';
+import { traduction } from 'commun/infra/internationalisation';
+
+describe('Le composant overlay erreur', function () {
+  let localVue;
+
+  beforeEach(function () {
+    localVue = createLocalVue();
+    localVue.prototype.$traduction = traduction;
+  });
+
+  describe('quand il peut être ignoré', function () {
+    let wrapper;
+    beforeEach(function () {
+      wrapper = shallowMount(OverlayErreur, { localVue, propsData: { boutonIgnorer: true } });
+    });
+
+    it("affiche le bouton et envoi l'évènement ignore erreur", function (done) {
+      expect(wrapper.findComponent('button').exists()).toBe(true);
+      wrapper.findComponent('button').trigger('click');
+      wrapper.vm.$nextTick(() => {
+        expect(wrapper.emitted()).toHaveProperty('ignoreErreur');
+        done();
+      });
+    });
+  });
+
+  describe('quand il ne peut pas être ignoré', function () {
+    let wrapper;
+    beforeEach(function () {
+      wrapper = shallowMount(OverlayErreur, { localVue, propsData: { boutonIgnorer: false } });
+    });
+
+    it("n'affiche pas le bouton", function () {
+      expect(wrapper.findComponent('button').exists()).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
J'ai mis un overlay opaque comme pour le message d'erreur lecture son car la vue derrière n'est pas le jeu mais l'espace de login.
<img width="754" alt="Capture d’écran 2022-08-23 à 17 15 59" src="https://user-images.githubusercontent.com/81169078/186197167-5484ee36-44b0-4cd0-a119-719b7a87899f.png">
Exemple du message d'erreur de lecture son
<img width="1075" alt="Capture d’écran 2022-08-23 à 17 24 44" src="https://user-images.githubusercontent.com/81169078/186198281-b4f64693-99a3-48a8-b026-da6d2a49eb1f.png">

