### PR TITLE
Fix ne renvoie pas le message d'erreur smartphone pour tablette

### DIFF
--- a/src/situations/accueil/vues/index.vue
+++ b/src/situations/accueil/vues/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="accueil">
     <div
-      v-if="estMobile && afficheErreurMobile && !estConnecte && !evaluationTerminee"
+      v-if="estSmartphone && afficheErreurSmartphone && !estConnecte && !evaluationTerminee"
       class="conteneur"
       style="position: absolute;"
     >
@@ -10,7 +10,7 @@
         :description="$traduction('situation.erreur_utilisation_smartphone.description')"
         :action="$traduction('situation.erreur_utilisation_smartphone.action')"
         :boutonIgnorer="true"
-        @ignoreErreur="afficheErreurMobile = false"/>
+        @ignoreErreur="afficheErreurSmartphone = false"/>
     </div>
     <div
       v-if="chargement || erreurChargement || erreurLectureSon"
@@ -34,7 +34,7 @@ import OverlayAttente from 'commun/vues/overlay_attente';
 import OverlayErreurChargement from 'commun/vues/overlay_erreur_chargement';
 import OverlayErreur from 'accueil/vues/overlay_erreur';
 import Accueil from './accueil';
-import { estMobile } from 'commun/helpers/mobile';
+import { estSmartphone } from 'commun/helpers/mobile';
 import { mapState } from 'vuex';
 
 export default {
@@ -49,8 +49,8 @@ export default {
       erreurLectureSon: false,
       forceCampagne: parametresUrl.code || '',
       forceNom: parametresUrl.nom || '',
-      estMobile: estMobile,
-      afficheErreurMobile: false
+      estSmartphone: estSmartphone,
+      afficheErreurSmartphone: false
     };
   },
 
@@ -59,8 +59,8 @@ export default {
   },
 
   mounted () {
-    if(this.estMobile) {
-      this.afficheErreurMobile = true;
+    if(this.estSmartphone) {
+      this.afficheErreurSmartphone = true;
     }
     this.$depotRessources.chargement().then(() => {
       this.chargement = false;

--- a/src/situations/commun/helpers/mobile.js
+++ b/src/situations/commun/helpers/mobile.js
@@ -1,5 +1,6 @@
-import { isMobile, isIOs, isAndroid } from 'mobile-device-detect';
+import { isMobile, isIOs, isAndroid, isMobileOnly } from 'mobile-device-detect';
 
 const estMobile = isMobile || isIOs || isAndroid;
+const estSmartphone = isMobileOnly;
 
-export { estMobile };
+export { estMobile, estSmartphone };

--- a/src/situations/commun/helpers/mobile.js
+++ b/src/situations/commun/helpers/mobile.js
@@ -1,6 +1,6 @@
 import { isMobile, isIOs, isAndroid, isMobileOnly } from 'mobile-device-detect';
 
-const estMobile = isMobile || isIOs || isAndroid;
+const estSmartphoneOuTablette = isMobile || isIOs || isAndroid;
 const estSmartphone = isMobileOnly;
 
-export { estMobile, estSmartphone };
+export { estSmartphoneOuTablette, estSmartphone };

--- a/src/situations/commun/vues/components/choix_bidirectionnel.vue
+++ b/src/situations/commun/vues/components/choix_bidirectionnel.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    v-if="estMobile"
+    v-if="estSmartphoneOuTablette"
     class="actions-fleches mobile"
     >
     <button
@@ -55,7 +55,7 @@ import Keypress from 'vue-keypress';
 import 'commun/styles/boutons.scss';
 import 'commun/styles/choix_bidirectionnel.scss';
 
-import { estMobile } from 'commun/helpers/mobile';
+import { estSmartphoneOuTablette } from 'commun/helpers/mobile';
 
 export const flecheGauche = 37;
 export const flecheDroite = 39;
@@ -99,7 +99,7 @@ export default {
 
   data () {
     return {
-      estMobile: estMobile,
+      estSmartphoneOuTablette: estSmartphoneOuTablette,
       choixGauche: 'gauche',
       choixDroit: 'droite',
       choixFait: null,

--- a/src/situations/plan_de_la_ville/data/defis.js
+++ b/src/situations/plan_de_la_ville/data/defis.js
@@ -6,7 +6,7 @@ import DeplacementDroiteMaisonVerte from '../assets/deplacement_droite_maison_ve
 import rouge from '../assets/rouge.svg';
 import vert from '../assets/vert.svg';
 import bleu from '../assets/bleu.svg';
-import { estMobile } from 'commun/helpers/mobile';
+import { estSmartphoneOuTablette } from 'commun/helpers/mobile';
 
 
 const modeEmploi = {
@@ -23,7 +23,7 @@ const clicMaisonBleue = {
   id: 'clic-maison-bleue',
   type: 'action',
   nom_technique: 'clic_maison_bleue',
-  nom_technique_mini_tuto: estMobile ? undefined : 'clic_maison_bleue',
+  nom_technique_mini_tuto: estSmartphoneOuTablette ? undefined : 'clic_maison_bleue',
   illustration: AccueilSansEglise,
   intitule: 'Cliquez sur la maison bleue',
   extensionVue: 'clic-maison-bleue'
@@ -32,11 +32,11 @@ const clicMaisonBleue = {
 const dragAndDrop = {
   id: 'drag-and-drop',
   type: 'action',
-  nom_technique: estMobile ? 'drag_and_drop_mobile' : 'drag_and_drop',
-  nom_technique_mini_tuto: estMobile ? undefined : 'drag_and_drop',
+  nom_technique: estSmartphoneOuTablette ? 'drag_and_drop_mobile' : 'drag_and_drop',
+  nom_technique_mini_tuto: estSmartphoneOuTablette ? undefined : 'drag_and_drop',
   illustration: IllustrationDragAndDrop,
   intitule: 'Super ! Maintenant, ajoutez une maison au village.',
-  modalite_reponse: estMobile ?
+  modalite_reponse: estSmartphoneOuTablette ?
     "Pour cela, posez votre doigt sur la maison dans le cadre blanc, et sans lever votre doigt, glissez jusqu'à la zone disponible." :
     "Pour cela cliquez sur la maison dans le cadre blanc, maintenez le bouton gauche de la souris enfoncé et glissez la dans la zone disponible.<br><br>Consultez l’exemple ci-dessous.",
   extensionVue: 'drag-and-drop'
@@ -87,7 +87,7 @@ const deplacementDroiteMaisonVerte = {
   id: 'deplacement-droite-maison-verte',
   type: 'action',
   nom_technique: 'deplacement_droite_maison_verte',
-  nom_technique_mini_tuto: estMobile ? undefined : 'deplacement_droite_maison_verte',
+  nom_technique_mini_tuto: estSmartphoneOuTablette ? undefined : 'deplacement_droite_maison_verte',
   illustration: DeplacementDroiteMaisonVerte,
   intitule: 'Dans quelle direction le personnage situé au milieu de l’écran doit-il aller pour se rendre à la maison verte ?',
   modalite_reponse: 'Pour répondre, appuyez sur la flèche gauche ou droite de votre clavier.<br><br>Sur tablette, les boutons affichés vous permettent de déplacer le personnage. Le bouton vert pour aller à gauche et le bouton rouge pour aller à droite.',

--- a/tests/situations/accueil/vues/index.test.js
+++ b/tests/situations/accueil/vues/index.test.js
@@ -133,14 +133,14 @@ describe('La vue index', function () {
           store,
           data() {
             return {
-              estMobile: true
+              estSmartphone: true
             };
           }
         });
       });
 
       it("affiche la vue erreur utilisation d'un smartphone", function () {
-        expect(wrapper.vm.afficheErreurMobile).toBe(true);
+        expect(wrapper.vm.afficheErreurSmartphone).toBe(true);
         expect(wrapper.findComponent(OverlayErreur).exists()).toBe(true);
         expect(wrapper.findComponent(OverlayErreur).props('titre')).toBe('situation.erreur_utilisation_smartphone.titre');
       });

--- a/tests/situations/commun/vues/components/choix_bidirectionnel.test.js
+++ b/tests/situations/commun/vues/components/choix_bidirectionnel.test.js
@@ -47,7 +47,7 @@ describe('La vue flèches clavier', function () {
 
   describe('sur ordinateur', function () {
     beforeEach(function () {
-      wrapper.vm.estMobile = false;
+      wrapper.vm.estSmartphoneOuTablette = false;
     });
 
     it("N'affiche pas les boutons permettant de répondre à la souris", function () {
@@ -57,7 +57,7 @@ describe('La vue flèches clavier', function () {
 
   describe('sur tablette', function () {
     beforeEach(function () {
-      wrapper.vm.estMobile = true;
+      wrapper.vm.estSmartphoneOuTablette = true;
     });
 
     it('affiche les boutons permettant de répondre avec le doigt', function () {


### PR DESCRIPTION
Dans cette PR, j'ai également rajouté un commit pour changer le nom du helper `estMobile` en `estSmartphoneOuTablette` qui m'a induit en erreur lors du développement du message d'erreur pour smartphone, pour plus de précision.