### PR TITLE
Nouvelle gestion des erreurs du formulaires de données sociodémographiques

### DIFF
--- a/src/situations/accueil/vues/formulaire_donnees_complementaires.vue
+++ b/src/situations/accueil/vues/formulaire_donnees_complementaires.vue
@@ -104,7 +104,6 @@ export default {
     },
 
     envoieFormulaire () {
-      this.erreurs = {};
       return this.$store.dispatch('enregistreDonneesComplementaires', {
         donnee_sociodemographique_attributes: {
           age: this.age,
@@ -112,10 +111,7 @@ export default {
           dernier_niveau_etude: this.nom_technique(this.dernier_niveau_etude),
           derniere_situation: this.nom_technique(this.derniere_situation)
         }
-      })
-        .catch((xhr) => {
-          this.erreurs = xhr.responseJSON;
-        });
+      });
     }
   }
 };


### PR DESCRIPTION
Les seules erreurs possibles sont des erreurs inattendues (erreurs réseau ou autre). Il n'y a aucun cas d'erreur de données à afficher sur le formulaire.

Le serveur retourne maintenant une erreur 500 si l'on n'envoie pas les bonnes valeurs pour les champs de sélection. Ces erreurs sont juste remontées pour être récupéré sur Rollbar.