### PR TITLE
Gère la déconnexion du bénéficaire dans le formulaire de données sociodemographiques

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -118,6 +118,10 @@ export function creeStore (registreUtilisateur, registreCampagne) {
 
       enregistreDonneesComplementaires ({ commit }, donneesSociodemographiques) {
         const idEvaluation = registreUtilisateur.idEvaluation();
+        if (!idEvaluation) {
+          commit('deconnecte');
+          return;
+        }
         return registreUtilisateur.enregistreDonneesComplementaires(idEvaluation, donneesSociodemographiques)
           .then(() => {
             commit('demarre');

--- a/tests/situations/accueil/modeles/store.test.js
+++ b/tests/situations/accueil/modeles/store.test.js
@@ -80,11 +80,24 @@ describe("Le store de l'accueil", function () {
     expect(store.state.nom).toEqual('');
   });
 
-  it('mets à jour les informations de contact', function () {
-    const store = creeStore(registreUtilisateur);
-    registreUtilisateur.idEvaluation = () => { return 1; };
-    return store.dispatch('enregistreDonneesComplementaires', 'mail@entreprise.fr', '0987654321').then(() => {
-      expect(store.state.etat).toEqual(DEMARRE);
+  describe('Action : enregistreDonneesComplementaires', function () {
+    let data = { age: '35', genre: 'Femme' };
+
+    it('démarre après avoir enregistré les données', function () {
+      const store = creeStore(registreUtilisateur);
+      registreUtilisateur.idEvaluation = () => { return 1; };
+      return store.dispatch('enregistreDonneesComplementaires', data).then(() => {
+        expect(store.state.etat).toEqual(DEMARRE);
+      });
+    });
+
+    it("déconnecte si l'id évaluation n'est pas connu", function () {
+      const store = creeStore(registreUtilisateur);
+      store.commit('connecte', 'test');
+      registreUtilisateur.idEvaluation = () => { return undefined; };
+      return store.dispatch('enregistreDonneesComplementaires', data).then(() => {
+        expect(store.state.estConnecte).toEqual(false);
+      });
     });
   });
 

--- a/tests/situations/commun/infra/registre_utilisateur.test.js
+++ b/tests/situations/commun/infra/registre_utilisateur.test.js
@@ -306,7 +306,7 @@ describe('le registre utilisateur', function () {
   describe('#enregistreDonneesComplementaires()', function () {
     describe('quand on est en ligne', function () {
       it("met à jour les informations de l'évaluation", function () {
-        const data = {age: '35', genre: 'Femme'};
+        const data = { age: '35', genre: 'Femme' };
         const registre = unRegistre({ id: 1, nom: 'test', age: data.age, genre: data.genre });
         return registre.enregistreDonneesComplementaires(1, data).then((utilisateur) => {
           expect(utilisateur.age).toEqual(data.age);


### PR DESCRIPTION
https://rollbar.com/eva-betagouv/eva/items/655/

Les utilisateurs qui sont sur le formulaire de données sociodémographique après avoir attendu trop longtemps ont une erreur parce que la déconnexion n’a pas été gérée.

Si l’utilisateur recharge la page, il peut même démarrer un parcours alors qu'aucune donnée ne peut être enregistrée.