### PR TITLE
Remplace classList.replace pour éviter d'envoyer une erreur quand le navigateur ne supporte pas la méthode

### DIFF
--- a/src/situations/inventaire/vues/contenu.js
+++ b/src/situations/inventaire/vues/contenu.js
@@ -20,7 +20,8 @@ export default class VueContenu {
 
   ferme (contenant) {
     this.calque.addEventListener('click', () => {
-      this.element.classList.replace('ouvrir', 'fermer');
+      this.element.classList.remove('ouvrir');
+      this.element.classList.add('fermer');
       this.journal.enregistre(new EvenementFermetureContenant({ contenant: contenant.id }));
       setTimeout(() => {
         this.element.remove();
@@ -49,7 +50,8 @@ export default class VueContenu {
     this.pointInsertion.appendChild(this.calque);
 
     setTimeout(() => {
-      this.element.classList.replace('fermer', 'ouvrir');
+      this.element.classList.remove('fermer');
+      this.element.classList.add('ouvrir');
     }, 50);
     this.ferme(contenant);
   }

--- a/src/situations/plan_de_la_ville/vues/components/drag_and_drop.vue
+++ b/src/situations/plan_de_la_ville/vues/components/drag_and_drop.vue
@@ -6,7 +6,11 @@
     <img
         :src="emplacementEglise"
         class="emplacement-eglise">
-    <svg ref="cercleBleu" class="cercle-bleu cercle-bleu--cache" width="222" height="222" viewBox="0 0 222 222" fill="none">
+    <svg
+      class="cercle-bleu"
+      :class="{ 'cercle-bleu--cache': !piece.selectionnee,
+                'cercle-bleu--visible': piece.selectionnee }"
+      width="222" height="222" viewBox="0 0 222 222" fill="none">
       <circle cx="111" cy="111" r="109.5" fill-opacity="0.8" stroke-width="3"/>
     </svg>
     <img
@@ -72,7 +76,6 @@ export default {
     },
 
     debuteSelection (event) {
-      this.$refs.cercleBleu.classList.replace('cercle-bleu--cache', 'cercle-bleu--visible');
       this.deplaceur.debuteSelection(this.piece, event);
     },
 
@@ -85,7 +88,6 @@ export default {
     },
 
     termineSelection () {
-      this.$refs.cercleBleu.classList.replace('cercle-bleu--visible', 'cercle-bleu--cache');
       this.deplaceur.termineSelection();
       this.reinitialisePositionPiece();
     },

--- a/tests/situations/plan_de_la_ville/vues/components/drag_and_drop.test.js
+++ b/tests/situations/plan_de_la_ville/vues/components/drag_and_drop.test.js
@@ -87,11 +87,14 @@ describe('glisser déposer', function () {
         expect(wrapper.vm.piece.estSelectionnee()).toBe(false);
       });
 
-      it("entoure d'un cercle bleu l'emplacement de l'église lorsque la maison est selectionnée", function () {
+      it("entoure d'un cercle bleu l'emplacement de l'église lorsque la maison est selectionnée", async function () {
         const cercleBleu = wrapper.find('.cercle-bleu');
         expect(cercleBleu.classes('cercle-bleu--cache')).toBe(true);
         expect(cercleBleu.classes('cercle-bleu--visible')).toBe(false);
         wrapper.find('.eglise-maison--a-placer').trigger('mousedown', { clientX: 95, clientY: 55 });
+
+        await wrapper.vm.$nextTick();
+
         expect(wrapper.vm.piece.estSelectionnee()).toBe(true);
         expect(cercleBleu.classes('cercle-bleu--cache')).toBe(false);
         expect(cercleBleu.classes('cercle-bleu--visible')).toBe(true);


### PR DESCRIPTION
Erreur rollbar : `TypeError: this.$refs.cercleBleu.classList.replace is not a function`

La méthode `classList.replace` est normalement bien supportée sur tous les navigateurs dont Chrome Android
https://developer.mozilla.org/en-US/docs/Web/API/Element/classList

Du coup c'est peut-être le chargement de l'image qui a posé problème lors de l'utilisation de la méthode. Je propose donc de s'assurer qu'elle est présente pour lancer l'aimation.


