### PR TITLE
:bug: N'affiche pas d'image lorsque la question ne trouve pas d'illustration

### DIFF
--- a/src/situations/bienvenue/infra/depot_ressources_bienvenue.js
+++ b/src/situations/bienvenue/infra/depot_ressources_bienvenue.js
@@ -1,4 +1,5 @@
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
+import fondSituation from 'questions/assets/illustration_questions/bienvenue_background.jpg';
 
 // QUESTIONS
 import sonConsigne from 'bienvenue/assets/consigne_demarrage_bienvenue.mp3';
@@ -157,6 +158,11 @@ const messagesAudios = { ...AUDIOS_QUESTIONS, ...AUDIOS_REPONSES };
 
 export default class DepotRessourcesBienvenue extends DepotRessourcesCommunes {
   constructor (chargeurs) {
-    super(chargeurs, messagesVideos, messagesAudios, null, sonConsigne);
+    super(chargeurs, messagesVideos, messagesAudios, fondSituation, sonConsigne);
+    this.charge([fondSituation]);
+  }
+
+  fondSituation () {
+    return this.ressource(fondSituation);
   }
 }

--- a/src/situations/commun/vues/question.vue
+++ b/src/situations/commun/vues/question.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="question">
     <img
-      :src="illustrationQuestion(question)"
+      :src="illustration"
       class="question-illustration"
     />
 
@@ -22,7 +22,20 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['illustrationQuestion'])
-  }
+    ...mapGetters(['illustrationQuestion']),
+
+    illustration(){
+      try {
+        return this.illustrationQuestion(this.question);
+      } catch (erreur) {
+        if (erreur.name === "illustrationIntrouvable") {
+          console.error(erreur);
+          return undefined;
+        } else {
+          throw erreur;
+        }
+      }
+    }
+  },
 };
 </script>

--- a/src/situations/commun/vues/question.vue
+++ b/src/situations/commun/vues/question.vue
@@ -22,15 +22,15 @@ export default {
     }
   },
   computed: {
-    ...mapGetters(['illustrationQuestion']),
+    ...mapGetters(['illustrationQuestion', 'fondSituation']),
 
     illustration(){
       try {
         return this.illustrationQuestion(this.question);
-      } catch (erreur) {
+      } catch(erreur) {
         if (erreur.name === "illustrationIntrouvable") {
           console.error(erreur);
-          return undefined;
+          return this.fondSituation;
         } else {
           throw erreur;
         }

--- a/src/situations/livraison/infra/depot_ressources_livraison.js
+++ b/src/situations/livraison/infra/depot_ressources_livraison.js
@@ -2,15 +2,20 @@ import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 
 import sonConsigne from 'livraison/assets/consigne_demarrage_livraison.mp3';
 import sonConsigneTransition from 'livraison/assets/consigne_transition_livraison.mp3';
+import fondSituation from 'questions/assets/illustration_questions/entrainement_livraison_1.jpg';
 
 const messagesVideos = {};
 
 export default class DepotRessourcesLivraison extends DepotRessourcesCommunes {
   constructor (chargeurs) {
-    super(chargeurs, messagesVideos, {}, null, sonConsigne, sonConsigneTransition);
+    super(chargeurs, messagesVideos, {}, fondSituation, sonConsigne, sonConsigneTransition);
   }
 
   imageAideComplementaire () {
     return this.calculatrice();
+  }
+
+  fondSituation () {
+    return this.ressource(fondSituation);
   }
 }

--- a/src/situations/questions/modeles/store.js
+++ b/src/situations/questions/modeles/store.js
@@ -13,11 +13,15 @@ export function creeStore () {
     state: {
       questions: [],
       indexQuestion: 0,
-      fini: false
+      fini: false,
+      fondSituation: '',
     },
     getters: {
       nombreQuestions (state) {
         return state.questions.length;
+      },
+      fondSituation(state) {
+        return state.fondSituation;
       },
       questionCourante (state) {
         return state.questions[state.indexQuestion];
@@ -33,7 +37,8 @@ export function creeStore () {
       }
     },
     mutations: {
-      configureActe (state, { questions }) {
+      configureActe (state, { questions, fondSituation }) {
+        state.fondSituation = fondSituation,
         state.questions = questions || [];
         state.indexQuestion = 0;
         state.fini = false;

--- a/src/situations/questions/modeles/store.js
+++ b/src/situations/questions/modeles/store.js
@@ -26,7 +26,9 @@ export function creeStore () {
         if (question.nom_technique && illustrationsQuestions[question.nom_technique]) {
           return illustrationsQuestions[question.nom_technique];
         } else {
-          throw new Error(`La question ${question.id} avec le nom technique "${question.nom_technique}" ne possède pas d'illustration`);
+          const erreur = new Error(`La question ${question.id} avec le nom technique "${question.nom_technique}" ne possède pas d'illustration`);
+          erreur.name = 'illustrationIntrouvable';
+          throw erreur;
         }
       }
     },

--- a/src/situations/questions/vues/situation.vue
+++ b/src/situations/questions/vues/situation.vue
@@ -7,14 +7,6 @@ export default {
   extends: Situation,
 
   props: {
-    configurationEntrainement: {
-      type: Object,
-      required: false
-    },
-    configurationNormale: {
-      type: Object,
-      required: false
-    },
     idSituation: {
       type: String,
       required: true
@@ -23,13 +15,15 @@ export default {
 
   computed: {
     acte () {
+      let questions = {};
       if ([DEMARRE, FINI].includes(this.etat)) {
-        return {
-          questions: new RegistreCampagne().questions(this.idSituation)
-        };
+        questions = new RegistreCampagne().questions(this.idSituation);
+      } else {
+        questions = new RegistreCampagne().questionsEntrainement(this.idSituation);
       }
       return {
-        questions: new RegistreCampagne().questionsEntrainement(this.idSituation)
+        questions: questions,
+        fondSituation: this.$depotRessources.fondSituation().src
       };
     }
   }

--- a/tests/situations/commun/vues/question.test.js
+++ b/tests/situations/commun/vues/question.test.js
@@ -6,13 +6,14 @@ import { traduction } from 'commun/infra/internationalisation';
 describe('La vue de la question', function () {
   let question;
   let store;
-  let wrapper;
 
   beforeEach(function () {
     question = { choix: [] };
     store = creeStore();
-    question.illustration = 'bienvenue_background.jpg';
-    wrapper = shallowMount(VueQuestion, {
+  });
+
+  function composant (question) {
+    return shallowMount(VueQuestion, {
       props: { question },
       global: {
         plugins: [store]
@@ -21,10 +22,26 @@ describe('La vue de la question', function () {
         $traduction: traduction
       }
     });
+  }
+
+  describe("lorsque la question a une illustration", function () {
+    beforeEach(function () {
+      question.illustration = 'bienvenue_background.jpg';
+    });
+
+    it("affiche l'image", function () {
+      const wrapper = composant(question);
+      expect(wrapper.find('.question-illustration').exists()).toBe(true);
+      expect(wrapper.find('.question-illustration').attributes('src')).toBe('bienvenue_background.jpg');
+    });
   });
 
-  it("affiche l'image", function () {
-    expect(wrapper.find('.question-illustration').exists()).toBe(true);
-    expect(wrapper.find('.question-illustration').attributes('src')).toBe('bienvenue_background.jpg');
+  describe("lorsque la question n'a pas d'illustration", function () {
+    it("affiche la question sans image", function () {
+      const wrapper = composant(question);
+      expect(wrapper.find('.question-barre').exists()).toBe(true);
+      expect(wrapper.find('.question-illustration').exists()).toBe(true);
+      expect(wrapper.find('.question-illustration').attributes("src")).toBe(undefined);
+    });
   });
 });


### PR DESCRIPTION
On continue d'envoyer une erreur mais on ne bloque plus l'utilisateur dans son parcours si la question n'a pas d'image d'arrière plan associée. On met le fond de la situation à la place..