### PR TITLE
Ne plante pas si une campagne est corrompue dans le localstorage

### DIFF
--- a/src/situations/commun/infra/registre_campagne.js
+++ b/src/situations/commun/infra/registre_campagne.js
@@ -52,6 +52,8 @@ export default class RegistreCampagne extends BaseRegistre {
 
   situation (identifiantSituation) {
     const campagne = this.recupereCampagneCourante();
+    if(!campagne || !campagne.situations) return;
+
     return campagne.situations.find(situation => situation.nom_technique === identifiantSituation);
   }
 

--- a/tests/situations/commun/infra/registre_campagne.test.js
+++ b/tests/situations/commun/infra/registre_campagne.test.js
@@ -144,6 +144,9 @@ describe('le registre campagne', function () {
       });
     });
 
+    describe('#situation', function () {
+    });
+
     describe('recupère les questions', function () {
       let registre;
 
@@ -183,6 +186,19 @@ describe('le registre campagne', function () {
 
       it("retoure un tableau vide si la situation n'est pas présente", function () {
         expect(registre.questions('bienvenue').length).toEqual(0);
+      });
+
+      it("retoure un tableau vide si la campagne n'est pas dans le localstorage", function () {
+        registre.assigneCampagneCourante('inconnue');
+        expect(registre.questions('livraison').length).toEqual(0);
+      });
+
+      it("retourne un tableau vide si la campagne est corrompue avec null", function() {
+        const campagneCorrompue = null;
+        window.localStorage.setItem('campagne_CORROMPUE', JSON.stringify(campagneCorrompue));
+        registre = new RegistreCampagne();
+        registre.assigneCampagneCourante('corrompue');
+        expect(registre.questions('livraison').length).toEqual(0);
       });
 
       it("retoure les questions d'entrainement d'une situation", function () {


### PR DESCRIPTION
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/745

Il faudrait voir pour provoquer une déconnexion du bénéficiaire.

Apparemment, la récupération des questions d'entrainement plante aussi si la campagne est corrompue… Et il faudrait aussi provoquer la déconnexion.
```
  questionsEntrainement (identifiantSituation) {
    return this.situation(identifiantSituation).questions_entrainement;
  }
```