### PR TITLE
Utilise le tag git de la release comme version de l'application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-vue": "^8.4.1",
         "favicons-webpack-plugin": "^6.0.0",
+        "git-rev-webpack-plugin": "^0.3.1",
         "git-revision-webpack-plugin": "^3.0",
         "html-webpack-plugin": "^5.5",
         "husky": "^8.0.3",
@@ -7911,6 +7912,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/git-rev-webpack-plugin": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/git-rev-webpack-plugin/-/git-rev-webpack-plugin-0.3.1.tgz",
+      "integrity": "sha512-PVZCR3AooZSc3vRqwXK/gGEJ339WwaszXcq+yP0vximqR02D01N+htLd2tG3eswiIGO3dpCMHa2IeNaALJfXHw==",
+      "dev": true
     },
     "node_modules/git-revision-webpack-plugin": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-vue": "^8.4.1",
     "favicons-webpack-plugin": "^6.0.0",
+    "git-rev-webpack-plugin": "^0.3.1",
     "git-revision-webpack-plugin": "^3.0",
     "html-webpack-plugin": "^5.5",
     "husky": "^8.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
 const { VueLoaderPlugin } = require('vue-loader');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const RollbarSourceMapPlugin = require('rollbar-sourcemap-webpack-plugin');
+const GitRevPlugin = require('git-rev-webpack-plugin');
+const gitRevPlugin = new GitRevPlugin();
 
 const devMode = process.env.NODE_ENV !== 'production';
 const situations = ['controle', 'inventaire', 'tri', 'questions', 'securite', 'prevention', 'maintenance', 'livraison', 'objets_trouves', 'bienvenue', 'plan_de_la_ville', 'cafe_de_la_place'];
@@ -115,6 +117,7 @@ module.exports = {
   plugins: [
     ...rollbarSourceMapPlugin,
     new CleanWebpackPlugin(),
+    gitRevPlugin,
     new MiniCssExtractPlugin({
       filename: '[name].css',
       chunkFilename: '[id].css'
@@ -131,7 +134,7 @@ module.exports = {
       JETON_CLIENT_ROLLBAR: null, // valeur par défaut null quand la variable est facultative
       ROLLBAR_ENV: null,
       SOURCE_VERSION: undefined,
-      SOURCE_VERSION_COURTE: devMode ? 'HEAD' : process.env.SOURCE_VERSION.substring(0, 8),
+      SOURCE_VERSION_COURTE: gitRevPlugin.tag(),
       ANNONCE_GENERALE: null,
       HOTJAR_ID: null,
       MATOMO_ID: null


### PR DESCRIPTION
Précédemment, on utilisait le SHA du commit, mais cela ne permet pas de référencer les versions de manière relative.
Avec cette modification, il est possible de dire : « Vérifier que votre version est plus récente que la version v20240328 ».

<img width="465" alt="Capture d’écran 2024-05-23 à 11 51 08" src="https://github.com/betagouv/eva/assets/298214/848fddfa-70e4-44aa-9d20-47b6ccb61cf1">
