### PR TITLE
🐛 Corrige le score envoyé lors de la sélection de la réponse

### DIFF
--- a/src/situations/cafe_de_la_place/modeles/store.js
+++ b/src/situations/cafe_de_la_place/modeles/store.js
@@ -94,8 +94,7 @@ export function creeStore () {
       enregistreReponse(state, reponse) {
         state.reponses[reponse.question] = reponse;
         if (state.carteActive.score) {
-          state.reponses[reponse.question].score = state.carteActive.score;
-
+          state.reponses[reponse.question].score = reponse.succes ? state.carteActive.score : 0;
         }
         if(reponse.succes && state.carteActive.score) {
           if(state.parcours == ORIENTATION) {

--- a/src/situations/cafe_de_la_place/vues/components/multi_select_mixin.js
+++ b/src/situations/cafe_de_la_place/vues/components/multi_select_mixin.js
@@ -19,10 +19,7 @@ export default {
         this.$emit('reponse');
       } else {
         const succes = estSucces(reponse, this.question.reponse.bonne_reponse);
-        let score;
-        if(succes) {
-          score = this.question.score;
-        }
+        const score = succes ? this.question.score : 0;
         this.$emit('reponse', { score, succes, reponse });
       }
     }

--- a/src/situations/cafe_de_la_place/vues/components/puzzle.vue
+++ b/src/situations/cafe_de_la_place/vues/components/puzzle.vue
@@ -74,8 +74,8 @@ export default {
   methods: {
     envoiReponse() {
       const reponse = this.fragmentsClasses.map((fragment) => fragment.position);
-      const score = this.calculeScore(reponse);
       const succes = this.succes(reponse);
+      const score = succes ? this.calculeScore(reponse) : 0;
       this.affichePuzzleDroite = reponse.length < this.nombreFragment;
       this.$emit('reponse', { score, succes, reponse });
     },

--- a/src/situations/commun/vues/defi.vue
+++ b/src/situations/commun/vues/defi.vue
@@ -180,7 +180,7 @@ export default {
       let scoreMax = undefined;
 
       if (this.question.choix) {
-        scoreMax = this.scoreMaxDepuisChoix(this.question.choix);
+        scoreMax = this.question.score;
       }
 
       if (this.question.reponse) {
@@ -188,13 +188,6 @@ export default {
       }
 
       return scoreMax;
-    },
-
-    scoreMaxDepuisChoix(choix) {
-      return choix.reduce((max) => {
-        if (!max) return this.question.score;
-        return (this.question.score > max) ? this.question.score : max;
-      }, undefined);
     },
 
     scoreMaxDepuisReponse() {

--- a/src/situations/commun/vues/defi/qcm.vue
+++ b/src/situations/commun/vues/defi/qcm.vue
@@ -66,7 +66,8 @@ export default {
     selectReponse (valeur) {
       this.reponse = valeur;
       const choix = this.question.choix.find((choix) => choix.id === this.reponse);
-      this.$emit('reponse', { reponse: choix.id, succes: choix.bonneReponse, score: choix.score });
+      const score = choix.bonneReponse ? this.question.score : 0;
+      this.$emit('reponse', { reponse: choix.id, succes: choix.bonneReponse, score: score });
     }
   }
 };

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -73,7 +73,7 @@ export function creeStore () {
 
       enregistreReponse(state, reponse) {
         state.reponses[reponse.question] = reponse;
-        state.reponses[reponse.question].score = state.carteActive.score;
+        state.reponses[reponse.question].score = reponse.succes ? state.carteActive.score : 0;
         if(reponse.succes) {
           state.pourcentageDeReussite += Math.round(state.carteActive.score / this.getters.maxScoreNiveauEnCours * 100);
         }

--- a/tests/situations/cafe_de_la_place/vues/components/clic_sur_mot.test.js
+++ b/tests/situations/cafe_de_la_place/vues/components/clic_sur_mot.test.js
@@ -136,7 +136,7 @@ describe('Le composant Clic Sur Mots', function () {
           liens.at(0).trigger('click');
           wrapper.vm.$nextTick(() => {
             expect(wrapper.emitted().reponse.length).toEqual(1);
-            expect(wrapper.emitted().reponse[0][0]).toEqual({ reponse: ['reponse1'], succes: false });
+            expect(wrapper.emitted().reponse[0][0]).toEqual({ reponse: ['reponse1'], succes: false, score: 0 });
             done();
           });
         });

--- a/tests/situations/cafe_de_la_place/vues/components/multi_select_mixin.test.js
+++ b/tests/situations/cafe_de_la_place/vues/components/multi_select_mixin.test.js
@@ -45,6 +45,7 @@ describe('Le mixin multi-select', function () {
       wrapper.vm.emetReponseMultiple(['belgique']);
       expect(wrapper.emitted().reponse[0][0]).toEqual({
         reponse: ['belgique'],
+        score: 0,
         succes: false
       });
     });
@@ -53,6 +54,7 @@ describe('Le mixin multi-select', function () {
       wrapper.vm.emetReponseMultiple(['allemagne', 'belgique']);
       expect(wrapper.emitted().reponse[0][0]).toEqual({
         reponse: ['allemagne', 'belgique'],
+        score: 0,
         succes: false
       });
     });
@@ -61,6 +63,7 @@ describe('Le mixin multi-select', function () {
       wrapper.vm.emetReponseMultiple(['allemagne', 'france', 'belgique']);
       expect(wrapper.emitted().reponse[0][0]).toEqual({
         reponse: ['allemagne', 'france', 'belgique'],
+        score: 0,
         succes: false
       });
     });

--- a/tests/situations/commun/vues/defi/qcm.test.js
+++ b/tests/situations/commun/vues/defi/qcm.test.js
@@ -63,7 +63,8 @@ describe('Le componsant defi QCM', function () {
 
   describe('envoie la réponse dans un événement input', function () {
     it('quand il y a une bonne réponse', function () {
-      question.choix = [{ id: 'uid-32', score: 1, bonneReponse: true }];
+      question.score = 1;
+      question.choix = [{ id: 'uid-32', bonneReponse: true }];
       const vue = composant(question);
       vue.find('input[type=radio][value=uid-32]').setChecked();
       expect(vue.emitted('reponse').length).toEqual(1);
@@ -75,15 +76,16 @@ describe('Le componsant defi QCM', function () {
       const vue = composant(question);
       vue.find('input[type=radio][value=uid-32]').setChecked();
       expect(vue.emitted('reponse').length).toEqual(1);
-      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32', succes: false });
+      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32', succes: false, score: 0 });
     });
 
     it('quand il y a une mauvaise réponse avec un score', function () {
-      question.choix = [{ id: 'uid-32', score: 0.5, bonneReponse: false }];
+      question.score = 0.5;
+      question.choix = [{ id: 'uid-32', bonneReponse: false }];
       const vue = composant(question);
       vue.find('input[type=radio][value=uid-32]').setChecked();
       expect(vue.emitted('reponse').length).toEqual(1);
-      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32', succes: false, score: 0.5 });
+      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32', succes: false, score: 0 });
     });
 
     it("quand il n'y a pas de bonne réponse", function () {
@@ -91,7 +93,7 @@ describe('Le componsant defi QCM', function () {
       const vue = composant(question);
       vue.find('input[type=radio][value=uid-32]').setChecked();
       expect(vue.emitted('reponse').length).toEqual(1);
-      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32' });
+      expect(vue.emitted('reponse')[0][0]).toEqual({ reponse: 'uid-32', score: 0 });
     });
   });
 });

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -121,7 +121,7 @@ describe('Le store de la situation place du marché', function () {
       store.state.carteActive = questionNiveau1Question1;
       let laReponse = { question: 'id1', reponse: 'ma reponse' };
       store.commit('enregistreReponse', laReponse);
-      laReponse = {...laReponse, score: 0.5};
+      laReponse = {...laReponse, score: 0};
       expect(store.getters.reponse('id1')).toEqual(laReponse);
     });
 


### PR DESCRIPTION
on envoie 0 par défaut quand la question est fausse. Le fait de mettre 0 était une logique présente avant dans le back :

https://github.com/betagouv/eva-serveur/blob/f83430d1c711ede65016ee936212600a0f55db53/app/models/restitution/export_cafe_de_la_place.rb#L48