### PR TITLE
🐛 Réinitialise rattrapages à passer à la fin d'un niveau avec un % de réussite > 70 et avant de passer au niveau suivant

### DIFF
--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -137,6 +137,7 @@ export function creeStore () {
         if (pourcentageDeReussiteGlobal > 70) {
           if (!estDernierNiveau) {
             state.indexNiveau += 1;
+            reinitialiseRattrapagesAPasser(state);
             this.commit('demarreParcours', NIVEAUX[state.indexNiveau]);
           } else {
             state.termine = true;
@@ -222,4 +223,15 @@ export function recupereReponsesMeilleursScores(meilleursScores, reponses) {
   return meilleursScores.flatMap(metrique =>
     Object.values(reponses).filter(e => e.question.startsWith(metrique))
   );
+}
+
+export function reinitialiseRattrapagesAPasser(state) {
+  state.pourcentageDeReussiteCompetence = {
+    'N1Prn': 100,
+    'N1Pde': 100,
+    'N1Pes': 100,
+    'N1Pon': 100,
+    'N1Poa': 100,
+    'N1Pos': 100,
+  };
 }

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -182,6 +182,18 @@ describe('Le store de la situation place du marché', function () {
             });
           });
         });
+
+        it('réinitialise les rattrapages à passer avant de passer au niveau suivant', function() {
+          store.state.pourcentageDeReussiteGlobal = 71;
+          store.state.pourcentageDeReussiteCompetence = {
+            'N1Prn': 69,
+          };
+          expect(store.getters.rattrapagesAPasser).toEqual(['N1Prn']);
+
+          store.commit('carteSuivante');
+
+          expect(store.getters.rattrapagesAPasser).toEqual([]);
+        });
       });
 
       describe('à la dernière question tu rattrapage', function() {


### PR DESCRIPTION
Bug détecté grâce à l'erreur rollbar :
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/940?utm_campaign=new_item_message&utm_medium=slack&utm_source=rollbar-notification

À la fin d'un niveau sans passer le rattrapage avec un % de réussite > 70 et < 100, on était redirigé vers le niveau suivant puis à la fin de la situation on devait passer le rattrapage présupposé que l'on aurait dû passer si on avait eu un % de réussite < à 70.

Solution implémenté : Réinitialiser les rattrapages à passer à la fin d'un niveau.