### PR TITLE
Le joueur utilise automatiquement le paramétrage de sa question QCM numératie

### DIFF
--- a/docs/tech-dive-in/EVA-171-le-joueur-utilise-automatiquement-le-parametrage-de-sa-question-qcm-numeratie/readme.md
+++ b/docs/tech-dive-in/EVA-171-le-joueur-utilise-automatiquement-le-parametrage-de-sa-question-qcm-numeratie/readme.md
@@ -1,0 +1,77 @@
+<!-- 📄 Standard : https://www.notion.so/captive/Le-cadrage-technique-dbb611e45f114737a6b14745caa584e9?pvs=4 -->
+# Le joueur utilise automatiquement le paramétrage de sa question QCM numératie
+
+> [EVA-171](https://captive-team.atlassian.net/browse/EVA-171)
+
+## Backend
+
+- Créer quelques questions numératie côté back pour tester la feature dans une migration
+- Créer le questionnaire Numératie pour la situation place du marché avec les questions
+
+## Frontend
+
+- Récupérer les questions du back à l'initialisation de la configuration de place du marché
+
+```javascript
+import RegistreCampagne from 'commun/infra/registre_campagne';
+
+  configureActe (state, configuration) {
+    // Ajout de la ligne suivante
+    state.questions = new RegistreCampagne().questions('place_du_marche')
+
+    state.configuration = configuration;
+    this.commit('demarreParcours', NIVEAU1);
+  },
+```
+
+- Surveille la question configuration en cours et render la question du back correspondante
+```javascript
+<template>
+  <transition-fade>
+    <defi
+      v-if="questionEnCours.id"
+      :key="questionEnCours.id"
+      :question="questionEnCours"
+      @reponse="reponse"
+    >
+      <pagination
+        :indexQuestion="indexCarte"
+        :nombreQuestions="nombreCartes"
+      />
+    </defi>
+  </transition-fade>
+</template>
+
+  data () {
+    return {
+      questionEnCours: {}
+    };
+  },
+  computed: {
+    ...mapState(['indexCarte', 'carteActive', 'termine', 'questions']),
+    ...mapGetters(['nombreCartes']),
+  },
+  watch: {
+    carteActive () {
+      this.questionEnCours = this.questions.filter(q => q.nom_technique === this.carteActive.nom_technique)
+    }
+  },
+```
+
+- Retirer les données des questions numératie du front qui sont envoyés par le back à savoir `intitule`, `modalite_reponse`, `type`, `choix`, `metacompetence`
+- Retirer les données des choix `intitule`, `bonneReponse`
+
+## Use case pour tester
+
+- Modifier une question côté back, relancer le jeu et voir si la modification est appliquée
+
+## Bonus Refacto
+
+- Utiliser une itération plutôt qu'une réassignation pour réinitialiser les rattrapages
+```javascript
+export function reinitialiseRattrapagesAPasser(state) {
+  Object.keys(state.pourcentageDeReussiteCompetence).forEach(competence => {
+    state.pourcentageDeReussiteCompetence[competence] = 100;
+  });
+};
+```

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -244,12 +244,7 @@ export function recupereReponsesMeilleursScores(meilleursScores, reponses) {
 }
 
 export function reinitialiseRattrapagesAPasser(state) {
-  state.pourcentageDeReussiteCompetence = {
-    'N1Prn': 100,
-    'N1Pde': 100,
-    'N1Pes': 100,
-    'N1Pon': 100,
-    'N1Poa': 100,
-    'N1Pos': 100,
-  };
+  Object.keys(state.pourcentageDeReussiteCompetence).forEach(competence => {
+    state.pourcentageDeReussiteCompetence[competence] = 100;
+  });
 }

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -86,6 +86,20 @@ export function creeStore () {
         if(!getters.rattrapageEnCours) return false;
         return state.questionActive.nom_technique.replace('R', 'P') === `${getters.rattrapagesAPasser[getters.rattrapagesAPasser.length - 1]}2` ?? false;
       },
+
+      questionServeur(state) {
+        const question = state.questions.filter(q => {
+          return q.nom_technique === state.questionActive.nom_technique;
+        })[0];
+        if(question) {
+          question.id = question.nom_technique;
+          question.score = state.questionActive.score;
+          question.choix.forEach(choix => {
+            choix.bonneReponse = choix.type_choix === 'bon';
+          });
+        }
+        return question;
+      }
     },
 
     mutations: {

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -1,6 +1,4 @@
 import { creeStore as creeStoreCommun } from 'commun/modeles/store';
-import RegistreCampagne from 'commun/infra/registre_campagne';
-
 
 export const NUMERATIE = 'numeratie';
 export const NIVEAU1 = 'niveau1';
@@ -104,7 +102,6 @@ export function creeStore () {
 
     mutations: {
       configureActe (state, configuration) {
-        state.questions = new RegistreCampagne().questions('place_du_marche');
         state.configuration = configuration;
         this.commit('demarreParcours', NIVEAU1);
       },
@@ -199,6 +196,10 @@ export function creeStore () {
 
         state.pourcentageDeReussiteGlobal =  calculPourcentage(scoreTotal, state.maxScoreNiveauEnCours);
       },
+
+      recupereQuestionsServeur(state, questions) {
+        state.questions = questions;
+      }
     },
   });
 }

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -1,4 +1,6 @@
 import { creeStore as creeStoreCommun } from 'commun/modeles/store';
+import RegistreCampagne from 'commun/infra/registre_campagne';
+
 
 export const NUMERATIE = 'numeratie';
 export const NIVEAU1 = 'niveau1';
@@ -88,6 +90,7 @@ export function creeStore () {
 
     mutations: {
       configureActe (state, configuration) {
+        state.questions = new RegistreCampagne().questions('place_du_marche');
         state.configuration = configuration;
         this.commit('demarreParcours', NIVEAU1);
       },

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -26,7 +26,7 @@ export function creeStore () {
       indexSerie: 0,
       indexNiveau: 0,
       indexRattrapage: 0,
-      carteActive: {},
+      questionActive: {},
       series: [],
       termine: false,
       reponses: {},
@@ -63,11 +63,11 @@ export function creeStore () {
       },
 
       codeCompetenceEnCours(state) {
-        return state.carteActive.nom_technique.substring(0, 5);
+        return state.questionActive.nom_technique.substring(0, 5);
       },
 
       estCompetenceARattraper(state) {
-        return state.carteActive.nom_technique.substring(0, 5) in state.pourcentageDeReussiteCompetence;
+        return state.questionActive.nom_technique.substring(0, 5) in state.pourcentageDeReussiteCompetence;
       },
 
       rattrapagesAPasser(state) {
@@ -84,8 +84,8 @@ export function creeStore () {
 
       estDerniereQuestionRattrapage(state, getters) {
         if(!getters.rattrapageEnCours) return false;
-        return state.carteActive.nom_technique.replace('R', 'P') === `${getters.rattrapagesAPasser[getters.rattrapagesAPasser.length - 1]}2` ?? false;
-      }
+        return state.questionActive.nom_technique.replace('R', 'P') === `${getters.rattrapagesAPasser[getters.rattrapagesAPasser.length - 1]}2` ?? false;
+      },
     },
 
     mutations: {
@@ -98,13 +98,13 @@ export function creeStore () {
       carteSuivanteParcours(state) {
         state.indexCarte++;
         if (state.indexCarte < state.series[state.indexSerie].cartes.length) {
-          state.carteActive = state.series[state.indexSerie].cartes[state.indexCarte];
+          state.questionActive = state.series[state.indexSerie].cartes[state.indexCarte];
         }
         else {
           state.indexCarte = 0;
           state.indexSerie++;
           if (state.indexSerie < state.series.length) {
-            state.carteActive = state.series[state.indexSerie].cartes[state.indexCarte];
+            state.questionActive = state.series[state.indexSerie].cartes[state.indexCarte];
           }
           else {
             state.indexSerie--;
@@ -121,7 +121,7 @@ export function creeStore () {
         state.indexCarte = 0;
         state.pourcentageDeReussiteGlobal = 0;
         state.series = state.configuration[state.parcours].series;
-        state.carteActive = state.series[state.indexSerie].cartes[state.indexCarte];
+        state.questionActive = state.series[state.indexSerie].cartes[state.indexCarte];
         if(!this.getters.rattrapageEnCours) {
           state.maxScoreNiveauEnCours = this.getters.maxScoreSerieEnCours;
         }
@@ -160,16 +160,16 @@ export function creeStore () {
 
       enregistreReponse(state, reponse) {
         const { question, succes } = reponse;
-        const { carteActive, pourcentageDeReussiteCompetence, reponses } = state;
+        const { questionActive, pourcentageDeReussiteCompetence, reponses } = state;
         const { rattrapageEnCours, estCompetenceARattraper, codeCompetenceEnCours, maxScoreSerieEnCours } = this.getters;
 
         reponses[question] = reponse;
-        reponses[question].score = succes ? carteActive.score : 0;
+        reponses[question].score = succes ? questionActive.score : 0;
 
         if (succes && !rattrapageEnCours) {
-          state.pourcentageDeReussiteGlobal += calculPourcentage(carteActive.score, maxScoreSerieEnCours);
+          state.pourcentageDeReussiteGlobal += calculPourcentage(questionActive.score, maxScoreSerieEnCours);
         } else if (!succes && estCompetenceARattraper) {
-          pourcentageDeReussiteCompetence[codeCompetenceEnCours] = calculPourcentage(carteActive.score, 2);
+          pourcentageDeReussiteCompetence[codeCompetenceEnCours] = calculPourcentage(questionActive.score, 2);
         }
       },
 

--- a/src/situations/place_du_marche/vues/place_du_marche.vue
+++ b/src/situations/place_du_marche/vues/place_du_marche.vue
@@ -26,7 +26,7 @@ export default {
   components: { Defi, TransitionFade, Pagination },
 
   computed: {
-    ...mapState(['indexCarte', 'carteActive', 'termine']),
+    ...mapState(['indexCarte', 'questionActive', 'termine']),
     ...mapGetters(['nombreCartes']),
   },
 

--- a/src/situations/place_du_marche/vues/place_du_marche.vue
+++ b/src/situations/place_du_marche/vues/place_du_marche.vue
@@ -1,9 +1,9 @@
 <template>
   <transition-fade>
     <defi
-      v-if="carteActive.id"
-      :key="carteActive.id"
-      :question="carteActive"
+      v-if="question.id"
+      :key="question.id"
+      :question="question"
       @reponse="reponse"
     >
       <pagination
@@ -25,14 +25,23 @@ import Pagination from 'commun/vues/components/pagination';
 export default {
   components: { Defi, TransitionFade, Pagination },
 
+  data () {
+    return {
+      question: {}
+    };
+  },
+
   computed: {
     ...mapState(['indexCarte', 'questionActive', 'termine']),
-    ...mapGetters(['nombreCartes']),
+    ...mapGetters(['nombreCartes', 'questionServeur']),
   },
 
   watch: {
     termine () {
       this.$emit('terminer');
+    },
+    questionActive() {
+      this.question = this.questionServeur ?? this.questionActive;
     }
   },
 

--- a/src/situations/place_du_marche/vues/place_du_marche.vue
+++ b/src/situations/place_du_marche/vues/place_du_marche.vue
@@ -17,6 +17,7 @@
 <script>
 import { mapState, mapGetters } from 'vuex';
 import EvenementReponse from 'questions/modeles/evenement_reponse';
+import RegistreCampagne from 'commun/infra/registre_campagne';
 
 import Defi from 'commun/vues/defi';
 import TransitionFade from 'commun/vues/transition_fade';
@@ -29,6 +30,11 @@ export default {
     return {
       question: {}
     };
+  },
+
+  mounted () {
+    const questions = new RegistreCampagne().questions('place_du_marche');
+    this.$store.commit('recupereQuestionsServeur', questions);
   },
 
   computed: {

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -344,6 +344,31 @@ describe('Le store de la situation place du marché', function () {
     });
   });
 
+  describe('#questionServeur', function() {
+    beforeEach(function() {
+      store.state.questionActive = { nom_technique: 'N1Prn1', score: 0.5 };
+    });
+
+    describe("si la question active a une question serveur avec le même nom technique", function() {
+      it("retourne la question serveur", function() {
+        const question = { nom_technique: 'N1Prn1', choix: [{ type_choix: 'bon' }, { type_choix: 'mauvaise' }] };
+        store.state.questions = [question];
+
+        expect(store.getters.questionServeur.id).toEqual('N1Prn1');
+        expect(store.getters.questionServeur.score).toEqual(0.5);
+        expect(store.getters.questionServeur.choix[0].bonneReponse).toBe(true);
+        expect(store.getters.questionServeur.choix[1].bonneReponse).toBe(false);
+      });
+    });
+
+    describe("si la question active n'a pas de question serveur avec le même nom technique", function() {
+      it('ne retourne rien', function() {
+        store.state.questions= [];
+        expect(store.getters.questionServeur).toBeUndefined();
+      });
+    });
+  });
+
   describe('Helper Functions', () => {
     const mockReponses = [
       { question: 'N1Pse1', score: 0.5 },

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -55,7 +55,7 @@ describe('Le store de la situation place du marché', function () {
 
     it("s'initialise avec le premier chapitre et la première carte du chapitre", function () {
       expect(store.state.indexCarte).toEqual(0);
-      expect(store.state.carteActive).toEqual(questionNiveau1Question1);
+      expect(store.state.questionActive).toEqual(questionNiveau1Question1);
     });
 
     describe("#nombreCartes", function() {
@@ -83,7 +83,7 @@ describe('Le store de la situation place du marché', function () {
         expect(store.getters.estDerniereQuestionRattrapage).toEqual(false);
 
         store.state.parcours = 'N1Rrn';
-        store.state.carteActive = { nom_technique: 'N1Roa2' };
+        store.state.questionActive = { nom_technique: 'N1Roa2' };
         store.state.pourcentageDeReussiteCompetence['N1Prn'] = 50;
         store.state.pourcentageDeReussiteCompetence['N1Poa'] = 50;
 
@@ -95,23 +95,23 @@ describe('Le store de la situation place du marché', function () {
       it("passe à la question suivante", function() {
         store.commit('carteSuivanteParcours');
 
-        expect(store.state.carteActive).toEqual(questionNiveau1Question2);
+        expect(store.state.questionActive).toEqual(questionNiveau1Question2);
       });
 
       it("passe de la dernière question du jeu de cartes en cours à la première question du jeu suivant", function() {
         store.state.indexCarte = 1;
         store.commit('carteSuivanteParcours');
 
-        expect(store.state.carteActive).toEqual(questionNiveau1Question3);
+        expect(store.state.questionActive).toEqual(questionNiveau1Question3);
       });
 
       it("termine le parcours après la dernière question", function() {
         store.state.indexCarte = 0;
         store.state.indexSerie = 1;
-        store.state.carteActive = questionNiveau2;
+        store.state.questionActive = questionNiveau2;
         store.commit('carteSuivanteParcours');
         expect(store.state.parcoursTermine).toBe(true);
-        expect(store.state.carteActive).toEqual(questionNiveau2);
+        expect(store.state.questionActive).toEqual(questionNiveau2);
         expect(store.getters.nombreCartes).toEqual(1);
       });
     });
@@ -121,14 +121,14 @@ describe('Le store de la situation place du marché', function () {
         beforeEach(function() {
           store.state.indexCarte = 0;
           store.state.indexSerie = 1;
-          store.state.carteActive = questionNiveau2;
+          store.state.questionActive = questionNiveau2;
         });
 
         it("termine la situation après la dernière question du dernier niveau", function () {
-          expect(store.state.carteActive).toEqual(questionNiveau2);
+          expect(store.state.questionActive).toEqual(questionNiveau2);
           expect(store.state.termine).toBe(false);
           store.commit('carteSuivante');
-          expect(store.state.carteActive).toEqual(questionNiveau2);
+          expect(store.state.questionActive).toEqual(questionNiveau2);
           expect(store.state.termine).toBe(true);
         });
       });
@@ -225,7 +225,7 @@ describe('Le store de la situation place du marché', function () {
       it('retourne vrai si la compétence de la question en cours est à rattraper', function() {
         expect(store.getters.estCompetenceARattraper).toBe(false);
         questionAvecRattrapage.nom_technique = 'N1Prn1';
-        store.state.carteActive = questionAvecRattrapage;
+        store.state.questionActive = questionAvecRattrapage;
         expect(store.getters.estCompetenceARattraper).toBe(true);
       });
     });
@@ -253,7 +253,7 @@ describe('Le store de la situation place du marché', function () {
 
   describe("#enregistreReponse", function() {
     it('peut enregistrer une réponse et la restituer', function() {
-      store.state.carteActive = questionNiveau1Question1;
+      store.state.questionActive = questionNiveau1Question1;
       let laReponse = { question: 'id1', reponse: 'ma reponse' };
       store.commit('enregistreReponse', laReponse);
       laReponse = {...laReponse, score: 0};
@@ -265,7 +265,7 @@ describe('Le store de la situation place du marché', function () {
         store.state.parcours = NIVEAU1;
         store.state.series = configuration[NIVEAU1].series;
         store.state.indexSerie = 0;
-        store.state.carteActive = questionNiveau1Question1;
+        store.state.questionActive = questionNiveau1Question1;
       });
 
       describe("quand la réponse est bonne et qu'aucun rattrapage n'est en cours", function() {
@@ -280,7 +280,7 @@ describe('Le store de la situation place du marché', function () {
           store.commit('enregistreReponse', { succes: true });
           expect(store.state.pourcentageDeReussiteGlobal).toEqual(20);
 
-          store.state.carteActive = questionNiveau1Question2;
+          store.state.questionActive = questionNiveau1Question2;
           store.commit('enregistreReponse', { succes: true });
           expect(store.state.pourcentageDeReussiteGlobal).toEqual(60);
         });
@@ -298,7 +298,7 @@ describe('Le store de la situation place du marché', function () {
       describe("quand la réponse est fausse et fait partie d'une compétence à rattraper", function() {
         it("décompte du pourcentage de réussite de la compétence", function() {
           questionAvecRattrapage.nom_technique = 'N1Prn1';
-          store.state.carteActive = questionAvecRattrapage;
+          store.state.questionActive = questionAvecRattrapage;
           store.commit('enregistreReponse', { succes: true });
           expect(store.state.pourcentageDeReussiteCompetence['N1Prn']).toEqual(100);
 
@@ -313,7 +313,7 @@ describe('Le store de la situation place du marché', function () {
     describe("si ce n'est pas la dernière question du rattrapage", function() {
       it("ne change rien", function() {
         store.state.parcours = NIVEAU1;
-        store.state.carteActive = questionNiveau1Question1;
+        store.state.questionActive = questionNiveau1Question1;
         store.state.pourcentageDeReussiteGlobal = 60;
 
         store.commit('recalculePourcentageReussiteGlobal');
@@ -329,7 +329,7 @@ describe('Le store de la situation place du marché', function () {
           'N1Prn1': { question: 'N1Prn1', succes: true, score: 0 },
           'N1Rrn1': { question: 'N1Rrn1', succes: true, score: 1 },
         };
-        store.state.carteActive = { nom_technique: 'N1Rrn2' };
+        store.state.questionActive = { nom_technique: 'N1Rrn2' };
         store.state.pourcentageDeReussiteCompetence = {
           'N1Prn': 40,
         };

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -6,6 +6,7 @@ import {
   additionneScores,
   calculPourcentage,
   recupereReponsesMeilleursScores,
+  reinitialiseRattrapagesAPasser,
   calculeScoreParMetrique,
   filtreMeilleursScores
 } from 'place_du_marche/modeles/store';
@@ -455,6 +456,24 @@ describe('Le store de la situation place du marché', function () {
           { question: 'N1Rde1', score: 1 },
           { question: 'N1Rde2', score: 1 }
         ]);
+      });
+    });
+
+    describe('#reinitialiseRattrapagesAPasser', function() {
+      it('réinitialise rattrapages à passer', () => {
+        store.state.pourcentageDeReussiteCompetence = {
+          'N1Pde': 70,
+          'N1Pes': 100,
+        };
+        expect(store.getters.rattrapagesAPasser).toEqual(['N1Pde']);
+
+        reinitialiseRattrapagesAPasser(store.state);
+
+        expect(store.getters.rattrapagesAPasser).toEqual([]);
+        expect(store.state.pourcentageDeReussiteCompetence).toEqual({
+          'N1Pde': 100,
+          'N1Pes': 100,
+        });
       });
     });
   });


### PR DESCRIPTION
Je n'ai pas fait de migration pour dupliquer toutes les questions numératie sur le back qu'on a déjà créé côté front suite au commentaire de Stéphane:
"en fait dans mon idée tu peux ajouter si tu veux, par contre elle ne serait prise en compte que si tu saisis le bon "code technique" (ou je ne sais plus comment ça s'appelle)"

Avec ce ticket, on peut créer une nouvelle QuestionQcm sur l'admin avec le bon nom_technique et si elle se trouve parmi les questions numératie qu'on a déjà paramétré côté front, alors le paramétrage du back est utilisé.

Tant qu'on a pas créer toutes les question numératie sur le back, la feature continue de fonctionner.

## DEMO : Ajout d'une question numératie sur l'admin


https://github.com/user-attachments/assets/eb818b52-2dfc-4770-8759-ad389754ae5e



## DEMO : Modification d'un question numératie sur l'admin

https://github.com/user-attachments/assets/81a99275-515a-449d-ac70-ea37cd0c156f



## Côté Front
Actuellement pour Bienvenue par exemple, on récupère la campagne et les situations configurations avec les questions dès l'acceuil grâce à RegistreCampagne

```javascript
  recupereCampagne (codeCampagne) {
    return new Promise((resolve, reject) => {
      this.$.ajax({
        type: 'GET',
        url: `${this.urlServeur}/api/campagnes/${encodeURI(codeCampagne)}`,
        contentType: 'application/json; charset=utf-8',
        success: (campagne) => {
          this.enregistreEnLocale(this.cleCampagnePourLocalStorage(codeCampagne), campagne);
          resolve(campagne);
        },
        error: (xhr) => {
          if (this.activeModeHorsLigne(xhr)) {
            const localCampagne = this.recupereCampagneEnLocale(codeCampagne);
            if (Object.keys(localCampagne).length > 0) {
              resolve(localCampagne);
            } else {
              reject(new ErreurCampagne(traduction('accueil.erreurs.code_campagne_inconnu')));
            }
          } else {
            if (xhr.status === 404) {
              reject(new ErreurCampagne(traduction('accueil.erreurs.code_campagne_inconnu')));
            } else {
              reject(xhr);
            }
          }
        }
      });
    });
  }

  recupereCampagneCourante () {
    const codeCampagne = window.localStorage.getItem('campagneCourante');
    return this.recupereCampagneEnLocale(codeCampagne);
  }

  recupereCampagneEnLocale (codeCampagne) {
    return this.parseLocalStorage(this.cleCampagnePourLocalStorage(codeCampagne));
  }

  cleCampagnePourLocalStorage (codeCampagne) {
    if (codeCampagne) return `campagne_${codeCampagne.toUpperCase()}`;
  }

  situation (identifiantSituation) {
    const campagne = this.recupereCampagneCourante();
    return campagne.situations.find(situation => situation.nom_technique === identifiantSituation);
  }

  questions (identifiantSituation) {
    const situation = this.situation(identifiantSituation);
    return situation && situation.questions ? situation.questions : [];
  }
```

## Côté Back

On envoie une campagne
```ruby
json.libelle campagne.libelle
json.code campagne.code
json.situations campagne.situations_configurations,
                partial: 'api/situations_configurations/situation_configuration',
                as: :situation_configuration
```

Avec ses situations configurations associées
```ruby
json.id situation_configuration.situation_id
json.libelle situation_configuration.libelle
json.nom_technique situation_configuration.nom_technique

questionnaire = situation_configuration.questionnaire_utile
json.questionnaire_id questionnaire&.id
json.questions questionnaire&.questions

questionnaire_entrainement = situation_configuration.situation.questionnaire_entrainement
json.questionnaire_entrainement_id questionnaire_entrainement&.id
json.questions_entrainement questionnaire_entrainement&.questions
```
