### PR TITLE
Affiche le gros bouton lecture si la question a un audio_intitule sans écrit

### DIFF
--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -152,12 +152,15 @@ function extraitQuestionsReponsesAudios(questions) {
   return questions.reduce((acc, question) => {
     if (question.audio_url) {
       acc[question.nom_technique] = question.audio_url;
-      question.choix.forEach(choix => {
-        if (choix.audio_url) {
-          acc[choix.nom_technique] = choix.audio_url;
-        }
-      });
     }
+    if (question.intitule_audio) {
+      acc[`${question.nom_technique}_intitule_audio`] = question.intitule_audio;
+    }
+    question.choix.forEach(choix => {
+      if (choix.audio_url) {
+        acc[choix.nom_technique] = choix.audio_url;
+      }
+    });
     return acc;
   }, {});
 }

--- a/src/situations/commun/vues/question_entete.vue
+++ b/src/situations/commun/vues/question_entete.vue
@@ -27,7 +27,7 @@
       <p v-if="question.modalite_reponse" class="question-modalite-reponse"><span v-html="question.modalite_reponse"></span></p>
       <bouton-lecture
         v-if="afficheLectureQuestionAudio"
-        :nomTechnique="question.reponse.nom_technique"
+        :nomTechnique="nomTechniqueLectureQuestionAudio"
         :avecTexte="true"
         ref="boutonLectureQuestionAudio"
       />
@@ -60,7 +60,23 @@ export default {
     },
 
     afficheLectureQuestionAudio () {
+      return this.existeReponseAudio || !!this.existeIntituleAudioSansEcrit;
+    },
+
+    existeReponseAudio () {
       return this.question.reponse && this.$depotRessources.existeMessageAudio(this.question.reponse.nom_technique);
+    },
+
+    existeIntituleAudioSansEcrit () {
+      return this.question.intitule_audio && this.$depotRessources.existeMessageAudio(`${this.question.nom_technique}_intitule_audio`);
+    },
+
+    nomTechniqueLectureQuestionAudio() {
+      return this.existeReponseAudio
+        ? this.question.reponse.nom_technique
+        : this.existeIntituleAudioSansEcrit
+          ? `${this.question.nom_technique}_intitule_audio`
+          : '';
     }
   },
 

--- a/tests/situations/commun/vues/question_entete.test.js
+++ b/tests/situations/commun/vues/question_entete.test.js
@@ -72,18 +72,23 @@ describe('la vue du composant entête', function () {
   });
 
   describe('#afficheLectureQuestionAudio', function () {
-    beforeEach(function () {
-      depotRessources.existeMessageAudio =
-        (nom_technique) => nom_technique == 'cuisine';
-    });
-
     it('affiche un bouton lecture lorsque la réponse a un audio associé', function () {
+      depotRessources.existeMessageAudio =
+      (nom_technique) => nom_technique == 'cuisine';
       const vue = composant({ reponse: { nom_technique: 'cuisine' } });
       expect(vue.vm.afficheLectureQuestionAudio).toBe(true);
       expect(vue.vm.$refs.boutonLectureQuestionAudio).toBeDefined();
     });
 
-    it("n'affiche pas de bouton lecture lorsque la réponse n'a pas d'audio associé", function () {
+    it("affiche un bouton lecture lorsque l'intitulé a un audio associé", function () {
+      depotRessources.existeMessageAudio =
+      (nom_technique) => nom_technique == 'question1_intitule_audio';
+      const vue = composant({ nom_technique: 'question1', intitule_audio: 'audio.mp3' });
+      expect(vue.vm.afficheLectureQuestionAudio).toBe(true);
+      expect(vue.vm.$refs.boutonLectureQuestionAudio).toBeDefined();
+    });
+
+    it("n'affiche pas de bouton lecture lorsque la réponse n'a pas d'audio associé ni d'intitulé", function () {
       const vue = composant({ reponse: { } });
       expect(vue.vm.afficheLectureQuestionAudio).toBe(false);
       expect(vue.vm.$refs.boutonLectureQuestionAudio).not.toBeDefined();


### PR DESCRIPTION
## Avec un intitulé écrit et audio
<img width="851" alt="Capture d’écran 2024-08-21 à 15 12 39" src="https://github.com/user-attachments/assets/61e2b164-24ea-4b67-9b30-df7481d413ba">

## Avec un intitulé audio mais pas d'écrit
<img width="857" alt="Capture d’écran 2024-08-21 à 15 08 33" src="https://github.com/user-attachments/assets/abf0a11e-d887-43f7-9bb9-6ab00e534208">

