### PR TITLE
Corrige une faute d'accord dans le message d'accueil de bienvenue

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -215,7 +215,7 @@
   "bienvenue": {
     "titre": "Bienvenue",
     "intro_contexte": {
-      "message": "<p>Avant de commencer, pouvez-vous nous en dire plus sur vous ?</p><p>Vos informations nous servirons uniquement à produire des statistiques anonymes et à améliorer le service eva.</p>"
+      "message": "<p>Avant de commencer, pouvez-vous nous en dire plus sur vous ?</p><p>Vos informations nous serviront uniquement à produire des statistiques anonymes et à améliorer le service eva.</p>"
     }
   },
   "objets_trouves": {


### PR DESCRIPTION
Dans la phrase
« Vos informations nous serviront… »

Le « nous » n'est pas un pronom personnel ! :-) (Je fais le malin, mais je ne sais pas en dire beaucoup plus).