### PR TITLE
💄 Retirer l'animation de flottement de l'interraction glisser déposer…

### DIFF
--- a/src/situations/commun/vues/components/glisser_deposer.vue
+++ b/src/situations/commun/vues/components/glisser_deposer.vue
@@ -38,7 +38,7 @@
         :sort="false"
       >
         <template #item="{ element }">
-          <div :key="element.id" :class="[`glisser-deposer__item item--${element.nom_technique}`, { 'glisser-deposer__item--flottant': !elementGlisse }]">
+          <div :key="element.id" :class="`glisser-deposer__item item--${element.nom_technique}`">
             <slot name="item" :item="element" />
           </div>
         </template>

--- a/src/situations/place_du_marche/styles/glisser_deposer.scss
+++ b/src/situations/place_du_marche/styles/glisser_deposer.scss
@@ -69,11 +69,6 @@
 }
 
 .glisser-deposer--personnalise {
-  .glisser-deposer__item {
-    &--flottant {
-      animation: flottement 3s ease-in-out infinite;
-    }
-  }
   img  {
     display: block;
     margin: auto;


### PR DESCRIPTION
… de place du marché

L'animation n'était pas disponible sur café de la place. Le commit n'a pas d'effet sur l'unique autre question où on a une animation de flottaison qui est plan de la ville car la situation utilise un autre composant.