### PR TITLE
Calcule les meilleures scores du niveau 2 et 3 entre le parcours nomal et le rattrapage 

### DIFF
--- a/src/situations/place_du_marche/data/defis.js
+++ b/src/situations/place_du_marche/data/defis.js
@@ -3,9 +3,9 @@ import { N1Rrn, N1Rde, N1Res, N1Ron, N1Roa, N1Ros, N2Rlp, N2Rpe, N2Rsu, N2Rom, N
 
 const configurationNormale = {
   questions: {
-    'niveau1': niveau1,
-    'niveau2': niveau2,
-    'niveau3': niveau3,
+    'N1': niveau1,
+    'N2': niveau2,
+    'N3': niveau3,
     'N1Prn': N1Rrn,
     'N1Pde': N1Rde,
     'N1Pes': N1Res,

--- a/src/situations/place_du_marche/data/rattrapage.js
+++ b/src/situations/place_du_marche/data/rattrapage.js
@@ -93,14 +93,14 @@ const N1Ros2 = {
 
 const N2Rlp1  = {
   id: 'N2Rlp1 ',
-  nom_technique: 'N2Rlp1 ',
+  nom_technique: 'N2Rlp1',
   metacompetence: 'lecture_plan',
   score: 1,
 };
 
 const N2Rlp2  = {
   id: 'N2Rlp2 ',
-  nom_technique: 'N2Rlp2 ',
+  nom_technique: 'N2Rlp2',
   metacompetence: 'lecture_plan',
   score: 1,
 };

--- a/src/situations/place_du_marche/modeles/store.js
+++ b/src/situations/place_du_marche/modeles/store.js
@@ -4,9 +4,9 @@ import {
 } from 'commun/modeles/situation';
 
 export const NUMERATIE = 'numeratie';
-export const NIVEAU1 = 'niveau1';
-export const NIVEAU2 = 'niveau2';
-export const NIVEAU3 = 'niveau3';
+export const NIVEAU1 = 'N1';
+export const NIVEAU2 = 'N2';
+export const NIVEAU3 = 'N3';
 export const NIVEAUX = [NIVEAU1, NIVEAU2, NIVEAU3];
 export const numeratieMetriques = {
   'N1Pse': null,
@@ -16,7 +16,26 @@ export const numeratieMetriques = {
   'N1Pon': 'N1Ron',
   'N1Poa': 'N1Roa',
   'N1Pos': 'N1Ros',
-  'N1Pvn': null
+  'N1Pvn': null,
+  'N2Plp': 'N2Rlp',
+  'N2Ppe': 'N2Rpe',
+  'N2Psu': 'N2Rsu',
+  'N2Pom': 'N2Rom',
+  'N2Pon': 'N2Ron',
+  'N2Pod': 'N2Rod',
+  'N2Put': 'N2Rut',
+  'N2Prh': 'N2Rrh',
+  'N2Ptg': 'N2Rtg',
+  'N2Ppl': 'N2Rpl',
+  'N3Ppl': 'N3Rpl',
+  'N3Put': 'N3Rut',
+  'N3Pum': null,
+  'N3Pim': null,
+  'N3Ppo': 'N3Rpo',
+  'N3Ppr': 'N3Rpr',
+  'N3Pps': 'N3Rps',
+  'N3Pvo': 'N3Rvo',
+  'N3Prp': 'N3Rrp'
 };
 
 export function creeStore () {
@@ -215,8 +234,8 @@ export function creeStore () {
           return;
         }
 
-        const scoresParMetrique = calculeScoreParMetrique(state.reponses);
-        const meilleursScores = filtreMeilleursScores(scoresParMetrique);
+        const scoresParMetrique = calculeScoreParMetrique(state.reponses, NIVEAUX[state.indexNiveau]);
+        const meilleursScores = filtreMeilleursScores(scoresParMetrique, NIVEAUX[state.indexNiveau]);
         const reponses = recupereReponsesMeilleursScores(meilleursScores, state.reponses);
         const scoreTotal = additionneScores(reponses);
 
@@ -234,29 +253,33 @@ export function calculPourcentage(valeur, total) {
   return Math.round(valeur / total * 100);
 }
 
-export function calculeScoreParMetrique(reponses) {
+export function calculeScoreParMetrique(reponses, niveau) {
   const scoresTotaux = {};
 
   for (const [questionInitiale, rattrapage] of Object.entries(numeratieMetriques)) {
-    scoresTotaux[questionInitiale] = Object.values(reponses)
-      .filter(e => e.question.startsWith(questionInitiale))
-      .reduce((total, e) => total + e.score, 0);
-    if (rattrapage) {
-      scoresTotaux[rattrapage] = Object.values(reponses)
-        .filter(e => e.question.startsWith(rattrapage))
+    if (questionInitiale.startsWith(niveau)) {
+      scoresTotaux[questionInitiale] = Object.values(reponses)
+        .filter(e => e.question.startsWith(questionInitiale))
         .reduce((total, e) => total + e.score, 0);
+      if (rattrapage) {
+        scoresTotaux[rattrapage] = Object.values(reponses)
+          .filter(e => e.question.startsWith(rattrapage))
+          .reduce((total, e) => total + e.score, 0);
+      }
     }
   }
 
   return scoresTotaux;
 }
 
-export function filtreMeilleursScores(scoresParMetrique) {
-  return Object.keys(numeratieMetriques).map(question => {
-    const rattrapage = numeratieMetriques[question];
-    if (!rattrapage) return question;
-    return scoresParMetrique[question] > scoresParMetrique[rattrapage] ? question : rattrapage;
-  });
+export function filtreMeilleursScores(scoresParMetrique, niveau) {
+  return Object.keys(numeratieMetriques)
+    .filter(question => question.startsWith(niveau))
+    .map(question => {
+      const rattrapage = numeratieMetriques[question];
+      if (!rattrapage) return question;
+      return scoresParMetrique[question] > scoresParMetrique[rattrapage] ? question : rattrapage;
+    });
 }
 
 export function recupereReponsesMeilleursScores(meilleursScores, reponses) {

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -402,35 +402,34 @@ describe('Le store de la situation place du marché', function () {
 
     describe("#recalculePourcentageReussiteGlobal", function() {
       describe("si ce n'est pas la dernière question du rattrapage", function() {
-        it("ne change rien", function() {
+        beforeEach(function() {
           store.state.parcours = NIVEAU1;
           store.state.questionActive = questionNiveau1Question1;
           store.state.pourcentageDeReussiteGlobal = 60;
+        });
 
+        it("ne change rien", function() {
           store.commit('recalculePourcentageReussiteGlobal');
-
           expect(store.state.pourcentageDeReussiteGlobal).toEqual(60);
         });
       });
 
       describe("si c'est la dernière question du rattrapage", function() {
-        it('retourne le nouveau pourcentage de réussite global', function() {
+        beforeEach(function() {
           store.state.configuration = configuration.questions;
           store.state.parcours = 'N1Rrn';
           store.state.reponses = {
-            'N1Prn1': { question: 'N1Prn1', succes: true, score: 0 },
-            'N1Rrn1': { question: 'N1Rrn1', succes: true, score: 1 },
+            'N1Prn1': { question: 'N1Prn1', score: 0 },
+            'N1Rrn1': { question: 'N1Rrn1', score: 1 },
           };
           store.state.questionActive = { nom_technique: 'N1Rrn1' };
-          store.state.pourcentageDeReussiteCompetence = {
-            'N1Prn': 40,
-          };
+          store.state.pourcentageDeReussiteCompetence = { 'N1Prn': 40 };
           store.state.maxScoreNiveauEnCours = 2;
+        });
 
+        it('retourne le nouveau pourcentage de réussite global', function() {
           expect(store.state.pourcentageDeReussiteGlobal).toEqual(0);
-
           store.commit('recalculePourcentageReussiteGlobal');
-
           expect(store.state.pourcentageDeReussiteGlobal).toEqual(50);
         });
       });

--- a/tests/situations/place_du_marche/modeles/store.test.js
+++ b/tests/situations/place_du_marche/modeles/store.test.js
@@ -283,7 +283,7 @@ describe('Le store de la situation place du marché', function () {
       it('retourne vrai si le parcours en cours est le dernier niveau', function() {
         expect(store.getters.estDernierNiveau).toEqual(false);
 
-        store.state.parcours = 'niveau3';
+        store.state.parcours = NIVEAU3;
 
         expect(store.getters.estDernierNiveau).toEqual(true);
       });
@@ -291,7 +291,7 @@ describe('Le store de la situation place du marché', function () {
 
     describe('#tousLesParcours', function() {
       it('retourne tous les parcours', function() {
-        expect(store.getters.tousLesParcours).toEqual(['niveau1', 'niveau2', 'niveau3', 'N1Prn', 'N1Roa']);
+        expect(store.getters.tousLesParcours).toEqual([NIVEAU1, NIVEAU2, NIVEAU3, 'N1Prn', 'N1Roa']);
       });
     });
 
@@ -462,7 +462,7 @@ describe('Le store de la situation place du marché', function () {
 
     describe('#calculeScoreParMetrique', function() {
       it('filtre les réponses avec les scores', () => {
-        const result = calculeScoreParMetrique(mockReponses);
+        const result = calculeScoreParMetrique(mockReponses, NIVEAU1);
         expect(result).toEqual({
           "N1Pde": 1,
           "N1Pes": 0,
@@ -498,7 +498,7 @@ describe('Le store de la situation place du marché', function () {
           "N1Ron": 0,
           "N1Ros": 0,
           "N1Rrn": 0};
-        const result = filtreMeilleursScores(scoresParMetrique);
+        const result = filtreMeilleursScores(scoresParMetrique, NIVEAU1);
         expect(result).toEqual(["N1Pse", "N1Rrn", "N1Rde", "N1Res", "N1Ron", "N1Roa", "N1Ros", "N1Pvn"]);
       });
     });


### PR DESCRIPTION
Cette PR ajoute la configuration pour permettre le recalcule du pourcentage de réussite du niveau 2 et 3 si du rattrapage a été passé. La règle est qu'on garde le meilleur score entre le module normal et celui de rattrapage.
La configuration est historiquement faite pour le niveau 1.