### PR TITLE
🐛 Le jeu ne lance pas quand certains assets (mp3) ne sont pas chargés

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,16 @@ module.exports = {
       // and not allow any straggling "old" SWs to hang around
       clientsClaim: true,
       skipWaiting: true,
-      maximumFileSizeToCacheInBytes: 50000000
+      maximumFileSizeToCacheInBytes: 50000000,
+      // Permet de définir un comportement "crossorigin"
+      manifestTransforms: [
+        async (manifestEntries) => {
+          return manifestEntries.map((entry) => {
+            entry.crossorigin = 'use-credentials';
+            return entry;
+          });
+        },
+      ],
     }),
     new webpack.DefinePlugin({
       __VUE_OPTIONS_API__: true,


### PR DESCRIPTION
Ajoute crossorigin="use-credentials" dans le manifest.json

https://www.outsystems.com/forums/discussion/86597/pwa-app-resources-are-blocked-due-to-cors/