### PR TITLE
♻️ Remonte l'initialisation des ressources de cafe_de_la_place et place_du_marche

### DIFF
--- a/src/situations/cafe_de_la_place/infra/depot_ressources_cafe_de_la_place.js
+++ b/src/situations/cafe_de_la_place/infra/depot_ressources_cafe_de_la_place.js
@@ -1,5 +1,7 @@
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
+import RegistreCampagne from 'commun/infra/registre_campagne';
 import sonConsigne from 'cafe_de_la_place/assets/consigne_cafe_de_la_place.mp3';
+import sonConsigneBlanche from 'commun/assets/consigne_blanche.mp3';
 import fondSituation from 'cafe_de_la_place/assets/terrasse_cafe.png';
 import { extraitDictionnaire } from 'commun/infra/depot_ressources';
 
@@ -30,7 +32,8 @@ const messagesVideos = {};
 
 export default class DepotRessourcesCafeDeLaPlace extends DepotRessourcesCommunes {
   constructor (chargeurs) {
-    super(chargeurs, messagesVideos, messagesAudios, fondSituation, sonConsigne);
+    const questionsServeur = new RegistreCampagne().questions(['cafe_de_la_place']);
+    super(chargeurs, messagesVideos, messagesAudios, fondSituation, sonConsigne, sonConsigneBlanche, questionsServeur);
     this.charge([fondSituation]);
   }
 

--- a/src/situations/commun/infra/depot_ressources_communes.js
+++ b/src/situations/commun/infra/depot_ressources_communes.js
@@ -4,17 +4,15 @@ import calculatrice from 'commun/assets/calculatrice.svg';
 import iconeDeconnexion from 'commun/assets/sign_out.svg';
 import son from 'commun/assets/son.svg';
 import sonConsigneBlanche from 'commun/assets/consigne_blanche.mp3';
-import RegistreCampagne from 'commun/infra/registre_campagne';
 import { extraitQuestionsReponsesAudios } from 'commun/infra/depot_ressources';
 
 export default class DepotRessourcesCommunes extends DepotRessources {
-  constructor (chargeurs, messagesVideos, messagesAudios, fondConsigne, sonConsigneDemarrage, sonConsigneTransition = sonConsigneBlanche) {
-    const questionsServeur = new RegistreCampagne().questions(['cafe_de_la_place', 'place_du_marche']);
-    const messagesAudiosServeur = extraitQuestionsReponsesAudios(questionsServeur);
+  constructor (chargeurs, messagesVideos, messagesAudios, fondConsigne, sonConsigneDemarrage, sonConsigneTransition = sonConsigneBlanche, questionsServeur = []) {
     super(chargeurs);
     this.charge([casque, son, calculatrice, sonConsigneDemarrage, sonConsigneTransition, iconeDeconnexion]);
     this.charge(Object.values(messagesVideos));
     this.charge(Object.values(messagesAudios));
+    const messagesAudiosServeur = extraitQuestionsReponsesAudios(questionsServeur);
     this.charge(Object.values(messagesAudiosServeur));
     if (fondConsigne) {
       this.charge([fondConsigne]);

--- a/src/situations/place_du_marche/infra/depot_ressources_place_du_marche.js
+++ b/src/situations/place_du_marche/infra/depot_ressources_place_du_marche.js
@@ -1,5 +1,7 @@
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
+import RegistreCampagne from 'commun/infra/registre_campagne';
 import sonConsigne from 'place_du_marche/assets/consigne_place_du_marche.mp3';
+import sonConsigneBlanche from 'commun/assets/consigne_blanche.mp3';
 import fondSituation from 'bienvenue/assets/bienvenue_background.jpg';
 
 const messagesVideos = {};
@@ -7,7 +9,8 @@ const messagesAudios = {};
 
 export default class DepotRessourcesPlaceDuMarche extends DepotRessourcesCommunes {
   constructor (chargeurs) {
-    super(chargeurs, messagesVideos, messagesAudios, null, sonConsigne);
+    const questionsServeur = new RegistreCampagne().questions(['place_du_marche']);
+    super(chargeurs, messagesVideos, messagesAudios, null, sonConsigne, sonConsigneBlanche, questionsServeur);
     this.consigneEnCours = null;
     this.texteAide = null;
     this.charge([fondSituation]);

--- a/tests/situations/commun/infra/depot_ressources_communes.test.js
+++ b/tests/situations/commun/infra/depot_ressources_communes.test.js
@@ -8,14 +8,6 @@ const questionsServeur = [
   { id: 1, nom_technique: 'N1Prn1', type: 'glisser-deposer' }
 ];
 
-jest.mock('commun/infra/registre_campagne', () => {
-  return jest.fn().mockImplementation(() => {
-    return {
-      questions: jest.fn().mockReturnValue(questionsServeur)
-    };
-  });
-});
-
 describe('Le dépot de ressources communes', function () {
   const imgFondConsigne = 'fondConsigne.png';
   const sonConsigneDemarrage = 'consigneDemarrage.mp3';
@@ -45,7 +37,7 @@ describe('Le dépot de ressources communes', function () {
         return Promise.resolve(() => _video);
       }
     });
-    depot = new DepotRessourcesCommunes(_chargeurs, { videoQuestion1: videoQuestion1 }, { audioQuestion1: sonAudioQuestion1 }, imgFondConsigne, sonConsigneDemarrage, sonConsigneTransition);
+    depot = new DepotRessourcesCommunes(_chargeurs, { videoQuestion1: videoQuestion1 }, { audioQuestion1: sonAudioQuestion1 }, imgFondConsigne, sonConsigneDemarrage, sonConsigneTransition, questionsServeur);
   });
 
   it('étend DépotRessources', function () {
@@ -150,8 +142,9 @@ describe('Le dépot de ressources communes', function () {
       result = depot.questions();
     });
 
-    it('retourne les questions du serveur', function() {
+    it('retourne les questions du serveur en convertisant le champ type_choix en bonneReponse', function() {
       expect(result).toEqual(questionsServeur);
+      expect(result[0].choix).toEqual([{ bonneReponse: true }]);
     });
   });
 });


### PR DESCRIPTION
Ces ressources étaient faites dans "depot_ressources_commune" et donc, faites au moment de l'affichage de l'accueil.

Avec ce refactoring, ces ressources sont maintenant chargées seulement au moment du démarrage de la situation concernée