### PR TITLE
🐛 Renomme image_au_clic par image_au_clic_url afin de fixer l'affichage du curseur dans les questions clic sur image

### DIFF
--- a/src/situations/commun/vues/components/clic_dans_image.vue
+++ b/src/situations/commun/vues/components/clic_dans_image.vue
@@ -50,7 +50,7 @@ export default {
 
   methods: {
     cliqueDansImage(event) {
-      if(this.question.image_au_clic) {
+      if(this.question.image_au_clic_url) {
         this.placeCurseur(event);
       } else {
         if (event.target.tagName === 'svg') return;


### PR DESCRIPTION


Cela fait suite au renommage de image_au_clic en image_au_clic_url coté back