### PR TITLE
🐛 Questions clic dans l'image - Dernier état non pris en compte en cas de déselection

### DIFF
--- a/src/situations/commun/vues/components/clic_dans_image.vue
+++ b/src/situations/commun/vues/components/clic_dans_image.vue
@@ -85,6 +85,7 @@ export default {
     deselectionne(selection) {
       this.reponsesSelectionnees = this.reponsesSelectionnees.filter(reponse => reponse !== selection);
       selection.classList.remove('reponse--selectionnee');
+      this.envoiReponse();
     },
 
     envoiReponse() {

--- a/tests/situations/commun/vues/components/clic_dans_image.test.js
+++ b/tests/situations/commun/vues/components/clic_dans_image.test.js
@@ -180,6 +180,19 @@ describe('Le composant Clic Dans Image', function () {
       });
     });
 
+    describe('quand je déselectionne un element', function () {
+      it("recalcule le score", function () {
+        const reponses = wrapper.findAll('.bonne-reponse');
+        reponses[0].trigger('click');
+        expect(wrapper.emitted().reponse.length).toEqual(1);
+        expect(wrapper.emitted().reponse[0][0].score).toEqual(0.5);
+
+        reponses[0].trigger('click');
+        expect(wrapper.emitted().reponse.length).toEqual(2);
+        expect(wrapper.emitted().reponse[1][0].score).toEqual(0);
+      });
+    });
+
     describe('envoie des réponses', function () {
       it('émet une partie ou la totalité du score en fonction du nombre de bonnes réponses sélectionnées', function () {
         const reponses = wrapper.findAll('.bonne-reponse');


### PR DESCRIPTION
Quand je déselectionne une image, je dois recalculer le score

Avant on ne le faisais, ce qui fait que si on sélectionne les bonnes réponses, puis qu'on les déselectionnes, puis on valide (sans rien), alors on a le meilleur score

https://captive-team.atlassian.net/browse/EVA-353