### PR TITLE
🐛 Corrige 500 à la remonté d'erreur en cas de échec au décodage audio

### DIFF
--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -21,7 +21,10 @@ function chargeurAudio (src) {
             });
           },
           function (erreur) {
-            reject(new Error(`Erreur au décodage de ${src} : ${erreur.message}`));
+            const message = erreur && erreur.message
+              ? erreur.message
+              : 'Erreur inconnue lors du décodage audio';
+            reject(new Error(`Erreur au décodage de ${src} : ${message}`));
           }
         );
       } else {


### PR DESCRIPTION
https://app.rollbar.com/a/eva-betagouv/fix/item/eva/1203